### PR TITLE
[#9] main ブランチへのマージを develop からのみ許可する

### DIFF
--- a/.github/workflows/check-source-branch.yml
+++ b/.github/workflows/check-source-branch.yml
@@ -1,0 +1,19 @@
+name: Check Source Branch
+
+on:
+  pull_request:
+    branches:
+      - main
+
+jobs:
+  check-source-branch:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Verify PR source branch is develop
+        run: |
+          if [ "${{ github.head_ref }}" != "develop" ]; then
+            echo "Error: PRs to main must come from the develop branch."
+            echo "Current source branch: ${{ github.head_ref }}"
+            exit 1
+          fi
+          echo "Source branch check passed: ${{ github.head_ref }}"


### PR DESCRIPTION
## 概要
GitHub Actions ワークフローで `main` への PR のソースブランチが `develop` 以外の場合に失敗させ、`develop` からのみマージを許可するよう制限する。

## 変更内容
- `.github/workflows/check-source-branch.yml` を追加

## 対応 Issue
Closes #9