### PR TITLE
fix: frontend Dockerfileのビルドエラーを修正 #21

### DIFF
--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -12,6 +12,7 @@ RUN npm ci
 FROM base AS builder
 WORKDIR /app
 COPY --from=deps /app/node_modules ./node_modules
+COPY package.json ./
 COPY frontend/ ./frontend/
 RUN npm run build --workspace=frontend
 


### PR DESCRIPTION
## 変更内容

- builder stageにroot `package.json`のコピーを追加
- `npm run build --workspace=frontend` 実行時にworkspace設定が参照できるよう修正