### PR TITLE
deploy: Turbopack node_modules解決エラーを修正

### DIFF
--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -14,6 +14,8 @@ WORKDIR /app
 COPY --from=deps /app/node_modules ./node_modules
 COPY package.json ./
 COPY frontend/ ./frontend/
+# Turbopackがnode_modulesを解決できるようにシンボリックリンクを作成
+RUN ln -s /app/node_modules /app/frontend/node_modules
 RUN npm run build --workspace=frontend
 
 FROM base AS runner


### PR DESCRIPTION
## Summary
- frontend Dockerfile で `frontend/node_modules → /app/node_modules` のシンボリックリンクを作成
- Turbopackがnpmワークスペース構成でNext.jsパッケージを見つけられないエラーを修正

🤖 Generated with [Claude Code](https://claude.com/claude-code)