### PR TITLE
fix: Turbopackのワークスペースルート設定を追加 #21

### DIFF
--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -14,8 +14,6 @@ WORKDIR /app
 COPY --from=deps /app/node_modules ./node_modules
 COPY package.json ./
 COPY frontend/ ./frontend/
-# Turbopackがnode_modulesを解決できるようにシンボリックリンクを作成
-RUN ln -s /app/node_modules /app/frontend/node_modules
 RUN npm run build --workspace=frontend
 
 FROM base AS runner

--- a/frontend/next.config.ts
+++ b/frontend/next.config.ts
@@ -2,6 +2,10 @@ import type { NextConfig } from 'next';
 
 const nextConfig: NextConfig = {
   output: 'standalone',
+  // npmワークスペース構成でTurbopackがnode_modulesを解決できるようにルートを指定
+  turbopack: {
+    root: '../',
+  },
 };
 
 export default nextConfig;


### PR DESCRIPTION
## 変更内容

- `frontend/next.config.ts` に `turbopack.root: '../'` を追加
- TurbopackがDockerビルド時にnpmワークスペースのnode_modulesを解決できないエラーを修正
- Dockerfileからシンボリックリンク作成を削除