### PR TITLE
deploy: NODE_PATHによるPostCSSモジュール解決ワークアラウンド

### DIFF
--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -14,6 +14,9 @@ WORKDIR /app
 COPY --from=deps /app/node_modules ./node_modules
 COPY package.json ./
 COPY frontend/ ./frontend/
+# turbopack.rootのPostCSSチャイルドプロセスへの反映バグのワークアラウンド
+# https://github.com/vercel/next.js/issues/92060
+ENV NODE_PATH=/app/node_modules
 RUN npm run build --workspace=frontend
 
 FROM base AS runner

--- a/frontend/next.config.ts
+++ b/frontend/next.config.ts
@@ -2,10 +2,6 @@ import type { NextConfig } from 'next';
 
 const nextConfig: NextConfig = {
   output: 'standalone',
-  // npmワークスペース構成でTurbopackがnode_modulesを解決できるようにルートを指定
-  turbopack: {
-    root: '../',
-  },
 };
 
 export default nextConfig;


### PR DESCRIPTION
## Summary
- builderステージに`ENV NODE_PATH=/app/node_modules`を追加
- `turbopack.root`がPostCSSチャイルドプロセスに反映されないNext.js 16.2.1のバグのワークアラウンド
- 関連Issue: https://github.com/vercel/next.js/issues/92060

🤖 Generated with [Claude Code](https://claude.com/claude-code)