### PR TITLE
fix: turbopack.root + NODE_PATHの組み合わせでDockerビルドを修正 #21

### DIFF
--- a/frontend/next.config.ts
+++ b/frontend/next.config.ts
@@ -2,6 +2,10 @@ import type { NextConfig } from 'next';
 
 const nextConfig: NextConfig = {
   output: 'standalone',
+  // npmワークスペース構成でTurbopackがnext/package.jsonを解決できるようにルートを指定
+  turbopack: {
+    root: '../',
+  },
 };
 
 export default nextConfig;


### PR DESCRIPTION
## Summary

- `turbopack.root: '../'` を復元（Turbopackメインコンパイルで`next`パッケージを見つけるために必要）
- `ENV NODE_PATH=/app/node_modules`（PostCSSチャイルドプロセスのモジュール解決）
- 両方の設定が必要

## Test plan

- [ ] Dockerビルドが成功することを確認
- [ ] frontendコンテナ起動後、Next.jsが正常に起動することを確認
- [ ] PostCSSによるスタイル処理が正常に動作することを確認