### PR TITLE
deploy: turbopack.root + NODE_PATHでDockerビルドを修正

### DIFF
--- a/frontend/next.config.ts
+++ b/frontend/next.config.ts
@@ -2,6 +2,10 @@ import type { NextConfig } from 'next';
 
 const nextConfig: NextConfig = {
   output: 'standalone',
+  // npmワークスペース構成でTurbopackがnext/package.jsonを解決できるようにルートを指定
+  turbopack: {
+    root: '../',
+  },
 };
 
 export default nextConfig;


### PR DESCRIPTION
## Summary
- `turbopack.root: '../'` + `ENV NODE_PATH=/app/node_modules` の組み合わせで修正
- TurbopackメインコンパイルとPostCSSチャイルドプロセス両方のモジュール解決に対応

🤖 Generated with [Claude Code](https://claude.com/claude-code)