### PR TITLE
fix: turbopack.root設定を削除（#35対応） #21

### DIFF
--- a/frontend/next.config.ts
+++ b/frontend/next.config.ts
@@ -2,10 +2,6 @@ import type { NextConfig } from 'next';
 
 const nextConfig: NextConfig = {
   output: 'standalone',
-  // npmワークスペース構成でTurbopackがnext/package.jsonを解決できるようにルートを指定
-  turbopack: {
-    root: '../',
-  },
 };
 
 export default nextConfig;


### PR DESCRIPTION
## Summary

- Issue #35のnpmワークスペース廃止対応に伴い不要になった`turbopack.root`を削除
- frontendが独立したnode_modulesを持つようになったため設定不要

## Test plan

- [ ] frontendビルドが正常に完了することを確認
- [ ] Turbopack利用時にエラーが発生しないことを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)