### PR TITLE
fix: デプロイをSSMセッションマネージャー経由に変更 #21

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -56,18 +56,34 @@ jobs:
   deploy:
     needs: build-and-push
     runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+      contents: read
     steps:
-      - name: Deploy to EC2
-        uses: appleboy/ssh-action@v1
+      - name: Configure AWS credentials (OIDC)
+        uses: aws-actions/configure-aws-credentials@v4
         with:
-          host: ${{ secrets.EC2_HOST }}
-          username: ${{ secrets.EC2_USER }}
-          key: ${{ secrets.EC2_SSH_KEY }}
-          script: |
-            cd /home/${{ secrets.EC2_USER }}/credit-checker
-            export ECR_REGISTRY=${{ secrets.AWS_ACCOUNT_ID }}.dkr.ecr.${{ vars.AWS_REGION }}.amazonaws.com
-            export IMAGE_TAG=${{ needs.build-and-push.outputs.image_tag }}
-            aws ecr get-login-password --region ${{ vars.AWS_REGION }} | docker login --username AWS --password-stdin $ECR_REGISTRY
-            docker compose -f docker-compose.prod.yml pull
-            docker compose -f docker-compose.prod.yml up -d
-            docker image prune -f
+          role-to-assume: arn:aws:iam::${{ secrets.AWS_ACCOUNT_ID }}:role/github-actions-deploy-role
+          aws-region: ${{ env.AWS_REGION }}
+
+      - name: Deploy to EC2 via SSM
+        run: |
+          aws ssm send-command \
+            --instance-ids "${{ secrets.EC2_INSTANCE_ID }}" \
+            --document-name "AWS-RunShellScript" \
+            --parameters 'commands=[
+              "export ECR_REGISTRY=${{ secrets.AWS_ACCOUNT_ID }}.dkr.ecr.${{ vars.AWS_REGION }}.amazonaws.com",
+              "export IMAGE_TAG=${{ needs.build-and-push.outputs.image_tag }}",
+              "aws ecr get-login-password --region ${{ vars.AWS_REGION }} | docker login --username AWS --password-stdin $ECR_REGISTRY",
+              "cd /home/ec2-user/credit-checker",
+              "docker compose -f docker-compose.prod.yml pull",
+              "docker compose -f docker-compose.prod.yml up -d",
+              "docker image prune -f"
+            ]' \
+            --region "${{ vars.AWS_REGION }}" \
+            --output text \
+            --query "Command.CommandId" | xargs -I {} \
+            aws ssm wait command-executed \
+              --command-id {} \
+              --instance-id "${{ secrets.EC2_INSTANCE_ID }}" \
+              --region "${{ vars.AWS_REGION }}"


### PR DESCRIPTION
## Summary

- SSH（ポート22）不要になりセキュリティ向上
- `appleboy/ssh-action`を廃止し`aws ssm send-command`に変更
- GitHub Actions IAMロールにSSM権限が必要
- EC2 IAMロールに`AmazonSSMManagedInstanceCore`が必要
- `EC2_INSTANCE_ID` Secretの追加が必要

## Test plan

- [ ] GitHub Actions IAMロールにSSM権限（`ssm:SendCommand`, `ssm:GetCommandInvocation`）が付与されていることを確認
- [ ] EC2 IAMロールに`AmazonSSMManagedInstanceCore`ポリシーが付与されていることを確認
- [ ] GitHub SecretsにEC2_INSTANCE_IDが追加されていることを確認
- [ ] デプロイワークフローが正常に完了することを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)