### PR TITLE
fix: 本番環境でS3ServiceがAWS_ACCESS_KEY_IDを必須要求してクラッシュする (#46)

### DIFF
--- a/backend/src/s3/s3.service.ts
+++ b/backend/src/s3/s3.service.ts
@@ -19,14 +19,14 @@ export class S3Service {
 
   constructor(private readonly configService: ConfigService) {
     const endpoint = this.configService.get<string>('S3_ENDPOINT');
+    const accessKeyId = this.configService.get<string>('AWS_ACCESS_KEY_ID');
+    const secretAccessKey = this.configService.get<string>('AWS_SECRET_ACCESS_KEY');
     this.client = new S3Client({
       region: this.configService.getOrThrow<string>('AWS_REGION'),
-      credentials: {
-        accessKeyId: this.configService.getOrThrow<string>('AWS_ACCESS_KEY_ID'),
-        secretAccessKey: this.configService.getOrThrow<string>(
-          'AWS_SECRET_ACCESS_KEY',
-        ),
-      },
+      // 設定済みの場合のみ明示的に渡す（ローカル開発用）。未設定時はEC2 IAMロールを自動使用する
+      ...(accessKeyId && secretAccessKey
+        ? { credentials: { accessKeyId, secretAccessKey } }
+        : {}),
       // ローカル開発時のみLocalStackへ向ける。本番では未設定にしてAWSデフォルトエンドポイントを使用する
       ...(endpoint ? { endpoint, forcePathStyle: true } : {}),
     });


### PR DESCRIPTION
## Summary

- `S3Service` の `getOrThrow` を `get` に変更し、`AWS_ACCESS_KEY_ID` / `AWS_SECRET_ACCESS_KEY` を任意設定に変更
- 未設定時は AWS SDK がEC2 IAMロールの認証情報を自動使用する
- ローカル開発（LocalStack）では引き続き明示的なキーを使用

## 問題

本番EC2環境で `AWS_ACCESS_KEY_ID` が未設定のためバックエンドコンテナが起動直後にクラッシュしていた。

## Test plan

- [ ] ローカルで `docker compose up` し、S3アップロード・取得が動作することを確認
- [ ] 本番デプロイ後、バックエンドコンテナが正常起動することを確認
- [ ] レシート画像のアップロード・表示が動作することを確認

Closes #46

🤖 Generated with [Claude Code](https://claude.com/claude-code)