### PR TITLE
fix: 本番環境DB接続・SSL設定修正

### DIFF
--- a/backend/src/app.module.ts
+++ b/backend/src/app.module.ts
@@ -23,6 +23,8 @@ import { ChatModule } from './chat/chat.module';
       migrations: ['dist/migrations/*.js'],
       synchronize: false,
       logging: process.env.NODE_ENV === 'development',
+      // RDS はSSL必須。証明書チェーンの検証はスキップ（AWS管理の自己署名CA）
+      ssl: process.env.NODE_ENV === 'production' ? { rejectUnauthorized: false } : false,
     }),
     AuthModule,
     UsersModule,

--- a/docs/aws-design.md
+++ b/docs/aws-design.md
@@ -23,8 +23,9 @@ Internet
 NestJS のグローバルプレフィックスを `/api/v1` にすることで、NextAuth.js が使用する `/api/auth/*` と名前空間が分離される。
 
 > **EC2 セットアップ時の注意**: EC2 上の `.env` で以下を設定すること。
+> `BACKEND_URL` はコンテナ内からの接続のため Docker サービス名 `backend` を使用する（`localhost` はコンテナ自身を指すため不可）。
 > ```
-> BACKEND_URL=http://localhost:3003/api/v1
+> BACKEND_URL=http://backend:3003/api/v1
 > NEXT_PUBLIC_BACKEND_URL=https://<ドメイン>/api/v1
 > ```
 


### PR DESCRIPTION
## Summary

- TypeORMに本番環境用SSL設定を追加（RDS接続に必要）
- `docs/aws-design.md` のEC2セットアップ手順を更新

## 関連PR

- #49 fix: 本番RDS接続のSSL・DATABASE_URL設定修正

## デプロイ後のEC2手動作業

- [ ] `DATABASE_URL` の `#` を `%23` にURLエンコード済みか確認
- [ ] `BACKEND_URL=http://backend:3003/api/v1` になっているか確認
- [ ] `DATABASE_URL` に `?sslmode=require` が付いているか確認
- [ ] `docker compose -f docker-compose.prod.yml up -d --force-recreate` で再起動

🤖 Generated with [Claude Code](https://claude.com/claude-code)