### PR TITLE
fix: レシートアップロードのERR_CONNECTION_REFUSED修正（#53）

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ NEXTAUTH_URL=http://localhost:3000
 NEXTAUTH_SECRET=your_secret
 GOOGLE_CLIENT_ID=your_google_client_id
 GOOGLE_CLIENT_SECRET=your_google_client_secret
-NEXT_PUBLIC_API_URL=http://localhost:4000
+BACKEND_URL=http://localhost:3003
 ```
 
 **`backend/.env`（新規作成）**
@@ -109,7 +109,7 @@ cd ../backend && npm install
 # フロントエンド（localhost:3000）
 npm run dev:frontend
 
-# バックエンド（localhost:4000）
+# バックエンド（localhost:3003）
 npm run dev:backend
 ```
 

--- a/frontend/next.config.ts
+++ b/frontend/next.config.ts
@@ -2,6 +2,14 @@ import type { NextConfig } from 'next';
 
 const nextConfig: NextConfig = {
   output: 'standalone',
+  async rewrites() {
+    return [
+      {
+        source: '/api/backend/:path*',
+        destination: `${process.env.BACKEND_URL ?? 'http://localhost:3003'}/:path*`,
+      },
+    ];
+  },
 };
 
 export default nextConfig;

--- a/frontend/src/lib/api/chat.ts
+++ b/frontend/src/lib/api/chat.ts
@@ -6,7 +6,7 @@ import {
   ListMessagesResponse,
 } from '../../types/chat';
 
-const backendUrl = process.env.NEXT_PUBLIC_BACKEND_URL ?? 'http://localhost:3003';
+const backendUrl = '/api/backend';
 
 async function request<T>(
   path: string,

--- a/frontend/src/lib/api/receipts.ts
+++ b/frontend/src/lib/api/receipts.ts
@@ -8,7 +8,7 @@ import {
   UploadReceiptResponse,
 } from '../../types/receipt';
 
-const backendUrl = process.env.NEXT_PUBLIC_BACKEND_URL ?? 'http://localhost:3003';
+const backendUrl = '/api/backend';
 
 export async function getReceipt(
   id: string,


### PR DESCRIPTION
## 概要

ブラウザから直接バックエンドの `localhost:3003` へリクエストを送る実装になっており、デプロイ環境で `ERR_CONNECTION_REFUSED` が発生していた問題を修正する。

## 変更内容

- `next.config.ts` に rewrites を追加し、`/api/backend/:path*` → `BACKEND_URL/:path*` のサーバーサイドプロキシを設定
- `receipts.ts` / `chat.ts` のフェッチ先を `/api/backend` 相対パスに変更。ブラウザからバックエンドへ直接リクエストしない構成に変更
- `README.md` の環境変数名を `NEXT_PUBLIC_API_URL` → `BACKEND_URL` に統一、ポート表記も実装に合わせて 4000 → 3003 に修正

## 関連PR

- #54 (develop マージ済み)

Closes #53