### PR TITLE
fix: ローカル開発時のBACKEND_URLフォールバックにapi/v1プレフィックスを追加（#53）

### DIFF
--- a/frontend/next.config.ts
+++ b/frontend/next.config.ts
@@ -6,7 +6,7 @@ const nextConfig: NextConfig = {
     return [
       {
         source: '/api/backend/:path*',
-        destination: `${process.env.BACKEND_URL ?? 'http://localhost:3003'}/:path*`,
+        destination: `${process.env.BACKEND_URL ?? 'http://localhost:3003/api/v1'}/:path*`,
       },
     ];
   },


### PR DESCRIPTION
## 概要

`next.config.ts` の rewrites で `BACKEND_URL` 未設定時のフォールバック値が `http://localhost:3003` になっており、バックエンドのグローバルプレフィックス `api/v1` が抜けていたためローカル開発時に 404 になる問題を修正する。

## 変更内容

- `next.config.ts` のフォールバック値を `http://localhost:3003` → `http://localhost:3003/api/v1` に修正

## 補足

EC2 環境では `.env` に `BACKEND_URL=http://backend:3003/api/v1` が設定済みのため影響なし。ローカル開発時の動作修正。

関連: #53