### PR TITLE
fix: nginxのclient_max_body_sizeを設定して413エラーを解消する #58

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -76,6 +76,7 @@ jobs:
               "export IMAGE_TAG=${{ needs.build-and-push.outputs.image_tag }}",
               "aws ecr get-login-password --region ${{ vars.AWS_REGION }} | docker login --username AWS --password-stdin $ECR_REGISTRY",
               "cd /home/ec2-user/credit-checker",
+              "git pull origin main",
               "docker compose -f docker-compose.prod.yml pull",
               "docker compose -f docker-compose.prod.yml up -d",
               "docker image prune -f"

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -1,4 +1,14 @@
 services:
+  nginx:
+    image: nginx:1.27-alpine
+    restart: always
+    ports:
+      - "80:80"
+    volumes:
+      - ./nginx/default.conf:/etc/nginx/conf.d/default.conf:ro
+    depends_on:
+      - frontend
+
   frontend:
     image: ${ECR_REGISTRY}/credit-checker-frontend:${IMAGE_TAG:-latest}
     restart: always

--- a/nginx/default.conf
+++ b/nginx/default.conf
@@ -1,0 +1,14 @@
+server {
+    listen 80;
+
+    # アプリ側（NestJS）の上限に合わせて15MBに設定
+    client_max_body_size 15m;
+
+    location / {
+        proxy_pass http://frontend:3000;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+    }
+}


### PR DESCRIPTION
## 概要

nginxコンテナを本番環境（`docker-compose.prod.yml`）に追加し、`client_max_body_size 15m` を設定することで、ファイルアップロード時の 413 Request Entity Too Large エラーを解消します。

closes #58

## 変更内容

### nginx/default.conf（新規追加）
- `client_max_body_size 15m` を設定（NestJSバックエンド側の上限に合わせた値）
- frontendコンテナ（Next.js, port 3000）へのリバースプロキシ設定
- `X-Real-IP`、`X-Forwarded-For`、`X-Forwarded-Proto` ヘッダーを転送

### docker-compose.prod.yml（変更）
- `nginx:1.27-alpine` コンテナを追加
- ホストのポート 80 をnginxに割り当て
- `./nginx/default.conf` をコンテナにマウント（読み取り専用）
- frontendコンテナへの依存関係を設定

### .github/workflows/deploy.yml（変更）
- デプロイ時に `git pull origin main` を追加し、nginxの設定ファイルをEC2インスタンス上で最新化

## 動作確認ポイント

- [ ] 15MB以下のファイルアップロードが正常に完了すること
- [ ] 15MBを超えるファイルアップロード時に適切なエラーが返ること
- [ ] nginxコンテナが起動し、frontendへのプロキシが機能すること