### PR TITLE
add: nginxコンテナ追加とclient_max_body_size設定 (#58)

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -76,6 +76,7 @@ jobs:
               "export IMAGE_TAG=${{ needs.build-and-push.outputs.image_tag }}",
               "aws ecr get-login-password --region ${{ vars.AWS_REGION }} | docker login --username AWS --password-stdin $ECR_REGISTRY",
               "cd /home/ec2-user/credit-checker",
+              "git pull origin main",
               "docker compose -f docker-compose.prod.yml pull",
               "docker compose -f docker-compose.prod.yml up -d",
               "docker image prune -f"

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -1,4 +1,14 @@
 services:
+  nginx:
+    image: nginx:1.27-alpine
+    restart: always
+    ports:
+      - "80:80"
+    volumes:
+      - ./nginx/default.conf:/etc/nginx/conf.d/default.conf:ro
+    depends_on:
+      - frontend
+
   frontend:
     image: ${ECR_REGISTRY}/credit-checker-frontend:${IMAGE_TAG:-latest}
     restart: always

--- a/nginx/default.conf
+++ b/nginx/default.conf
@@ -1,0 +1,14 @@
+server {
+    listen 80;
+
+    # アプリ側（NestJS）の上限に合わせて15MBに設定
+    client_max_body_size 15m;
+
+    location / {
+        proxy_pass http://frontend:3000;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+    }
+}


### PR DESCRIPTION
## 概要

`develop` ブランチの変更を `main` へマージします。

## 変更内容

- **nginx コンテナの追加**（`docker-compose.prod.yml`）
  - `nginx:1.27-alpine` イメージを使用し、ポート80でリッスン
  - `frontend` コンテナへのリバースプロキシとして機能

- **nginx 設定ファイルの追加**（`nginx/default.conf`）
  - `client_max_body_size 15m` を設定（NestJS 側の上限に合わせて15MB）
  - `proxy_set_header` でリアルIPおよびForwardedヘッダーを転送

- **デプロイワークフローの更新**（`.github/workflows/deploy.yml`）
  - デプロイ時に `git pull origin main` を実行して最新の設定ファイルを取得するステップを追加

## 関連 Issue

- Close #58

## テスト計画

- [ ] 本番環境で nginx コンテナが正常に起動することを確認
- [ ] ファイルアップロード（15MB 以下）が正常に処理されることを確認
- [ ] デプロイ時に最新の nginx 設定が反映されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)