### PR TITLE
fix: EC2にgitをインストールし、deployワークフローのgit pullを確実に実行する (#65)

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -75,6 +75,7 @@ jobs:
               "export ECR_REGISTRY=${{ secrets.AWS_ACCOUNT_ID }}.dkr.ecr.${{ vars.AWS_REGION }}.amazonaws.com",
               "export IMAGE_TAG=${{ needs.build-and-push.outputs.image_tag }}",
               "aws ecr get-login-password --region ${{ vars.AWS_REGION }} | docker login --username AWS --password-stdin $ECR_REGISTRY",
+              "sudo yum install -y git || true",
               "cd /home/ec2-user/credit-checker",
               "git pull origin main",
               "sudo systemctl stop nginx 2>/dev/null || true",


### PR DESCRIPTION
## Summary

- SSM経由でのデプロイコマンドに `sudo yum install -y git || true` を追加
- SSMの実行環境ではPATHにgitが含まれないため、git pull前に明示的にインストールする
- `|| true` でインストール済みの場合もエラーにならないようにする

## Test plan

- [ ] mainへのpush後、GitHub Actionsのdeployジョブが正常完了することを確認
- [ ] EC2上で `docker-compose.prod.yml` の最新版が反映されてコンテナが起動することを確認

Closes #65

🤖 Generated with [Claude Code](https://claude.com/claude-code)