### PR TITLE
fix: デプロイ環境でレシートアップロード ERR_CONNECTION_REFUSED を修正 (#70)

### DIFF
--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -6,9 +6,11 @@ services:
       - "80:80"
       - "443:443"
     volumes:
-      - ./nginx/default.conf:/etc/nginx/conf.d/default.conf:ro
+      - ./nginx/default.conf.template:/etc/nginx/templates/default.conf.template:ro
       - /etc/letsencrypt:/etc/letsencrypt:ro       # EC2 上の既存証明書をマウント
       - certbot_www:/var/www/certbot               # ACME チャレンジ用
+    environment:
+      - BACKEND_UPSTREAM=${BACKEND_UPSTREAM}
     depends_on:
       - frontend
 
@@ -36,7 +38,6 @@ services:
       - AUTH_SECRET=${AUTH_SECRET}
       - AUTH_GOOGLE_ID=${AUTH_GOOGLE_ID}
       - AUTH_GOOGLE_SECRET=${AUTH_GOOGLE_SECRET}
-      - NEXT_PUBLIC_BACKEND_URL=${NEXT_PUBLIC_BACKEND_URL}
       - BACKEND_URL=${BACKEND_URL}
 
   backend:

--- a/frontend/next.config.ts
+++ b/frontend/next.config.ts
@@ -3,10 +3,13 @@ import type { NextConfig } from 'next';
 const nextConfig: NextConfig = {
   output: 'standalone',
   async rewrites() {
+    // 本番は nginx がルーティングするため不要
+    // ローカル開発時（npm run dev）は localhost:3003 に転送
+    if (process.env.NODE_ENV === 'production') return [];
     return [
       {
         source: '/api/backend/:path*',
-        destination: `${process.env.BACKEND_URL ?? 'http://localhost:3003/api/v1'}/:path*`,
+        destination: 'http://localhost:3003/api/v1/:path*',
       },
     ];
   },

--- a/nginx/default.conf.template
+++ b/nginx/default.conf.template
@@ -23,6 +23,14 @@ server {
     # アップロードファイルの上限（NestJS の MaxFileSizeValidator と合わせて余裕を持たせる）
     client_max_body_size 15m;
 
+    location /api/backend/ {
+        proxy_pass         ${BACKEND_UPSTREAM}/api/v1/;
+        proxy_set_header   Host              $host;
+        proxy_set_header   X-Real-IP         $remote_addr;
+        proxy_set_header   X-Forwarded-For   $proxy_add_x_forwarded_for;
+        proxy_set_header   X-Forwarded-Proto $scheme;
+    }
+
     location / {
         proxy_pass         http://frontend:3000;
         proxy_set_header   Host              $host;


### PR DESCRIPTION
## Summary

- `nginx/default.conf.template`: `/api/backend/` → `${BACKEND_UPSTREAM}/api/v1/` ルーティングを追加し、nginx が直接バックエンドに転送するよう変更
- `frontend/next.config.ts`: `rewrites()` を本番ビルド時は空配列に変更（ローカル開発環境は `localhost:3003` への転送を維持）
- `docker-compose.prod.yml`: nginx に `BACKEND_UPSTREAM` env var を追加、未使用の `NEXT_PUBLIC_BACKEND_URL` を削除

## ⚠️ デプロイ時の追加作業

EC2 の `.env` に以下を追加してください：

```env
# nginx テンプレート用（ブラウザ → nginx → backend ルーティング）
BACKEND_UPSTREAM=http://backend:3003

# auth.ts SSR 用（frontend コンテナ → backend コンテナ 内部通信）
BACKEND_URL=http://backend:3003
```

Closes #70

🤖 Generated with [Claude Code](https://claude.com/claude-code)