### PR TITLE
fix: middlewareのmatcherにapi/backendを除外し、レシート一覧が表示されない問題を修正 #67

### DIFF
--- a/frontend/middleware.ts
+++ b/frontend/middleware.ts
@@ -9,5 +9,5 @@ export default auth((req) => {
 });
 
 export const config = {
-  matcher: ['/((?!api/auth|_next/static|_next/image|favicon.ico).*)'],
+  matcher: ['/((?!api/auth|api/backend|_next/static|_next/image|favicon.ico).*)'],
 };


### PR DESCRIPTION
## 概要

レシート一覧にデータが表示されない問題を修正します。

## 原因

Next.js の Middleware が `/api/backend/*` へのサーバーサイド fetch をセッションクッキーなしと判断してブロックしていた。

## 対応

matcher から `api/backend` を除外。NestJS 側の JWT 認証が最終的な防衛線となるため、セキュリティ上の問題なし。

## 変更内容

- `frontend/middleware.ts` の matcher に `api/backend` を除外パターンとして追加
  - 変更前: `matcher: ['/((?!api/auth|_next/static|_next/image|favicon.ico).*)']`
  - 変更後: `matcher: ['/((?!api/auth|api/backend|_next/static|_next/image|favicon.ico).*)']`

🤖 Generated with [Claude Code](https://claude.com/claude-code)