### PR TITLE
fix: SSRでレシート一覧等のデータが取得できない問題 #75

### DIFF
--- a/frontend/src/lib/api/chat.ts
+++ b/frontend/src/lib/api/chat.ts
@@ -9,7 +9,7 @@ import {
 // SSRではNginxを経由しないため、バックエンドコンテナに直接通信する
 const backendUrl =
   typeof window === 'undefined'
-    ? (process.env.BACKEND_URL ?? 'http://localhost:3003/api/v1')
+    ? process.env.BACKEND_URL
     : '/api/backend';
 
 async function request<T>(

--- a/frontend/src/lib/api/receipts.ts
+++ b/frontend/src/lib/api/receipts.ts
@@ -11,7 +11,7 @@ import {
 // SSRではNginxを経由しないため、バックエンドコンテナに直接通信する
 const backendUrl =
   typeof window === 'undefined'
-    ? (process.env.BACKEND_URL ?? 'http://localhost:3003/api/v1')
+    ? process.env.BACKEND_URL
     : '/api/backend';
 
 export async function getReceipt(


### PR DESCRIPTION
## Summary
- `receipts.ts` と `chat.ts` でSSR（サーバーサイド）実行時に `BACKEND_URL` 環境変数を使いバックエンドコンテナに直接通信するよう修正
- クライアントサイドは従来通り `/api/backend`（Nginx経由）を使用
- `auth.ts` と同じアプローチを踏襲

## Background
Next.js Server Componentsがサーバー側で `/api/backend/receipts` を fetch する際、Nginxを経由しないため本番環境でリクエストが失敗しレシート一覧・ダッシュボードのデータが表示されない問題を修正。

Closes #75