### PR TITLE
develop → main

### DIFF
--- a/frontend/src/lib/api/chat.ts
+++ b/frontend/src/lib/api/chat.ts
@@ -6,7 +6,11 @@ import {
   ListMessagesResponse,
 } from '../../types/chat';
 
-const backendUrl = '/api/backend';
+// SSRではNginxを経由しないため、バックエンドコンテナに直接通信する
+const backendUrl =
+  typeof window === 'undefined'
+    ? process.env.BACKEND_URL
+    : '/api/backend';
 
 async function request<T>(
   path: string,

--- a/frontend/src/lib/api/receipts.ts
+++ b/frontend/src/lib/api/receipts.ts
@@ -8,7 +8,11 @@ import {
   UploadReceiptResponse,
 } from '../../types/receipt';
 
-const backendUrl = '/api/backend';
+// SSRではNginxを経由しないため、バックエンドコンテナに直接通信する
+const backendUrl =
+  typeof window === 'undefined'
+    ? process.env.BACKEND_URL
+    : '/api/backend';
 
 export async function getReceipt(
   id: string,


### PR DESCRIPTION
## 概要

`develop` ブランチで開発・マージされた全変更を `main` へ取り込むリリースPRです。

---

## 含まれる主な変更

### 初期構成・プロジェクトセットアップ
- モノレポ初期構成（Next.js / NestJS / ESLint/Prettier / Docker Compose）を追加
- TypeORMエンティティ・マイグレーション・シードデータを追加
- コード品質チェック用Hook設定を追加
- mainブランチへのマージをdevelopからのみ許可するGitHub Actions Workflowを追加

### 認証・DB
- Google OAuth認証を実装（#15）
- `raw_text` カラムを `gpt_response`（JSONB型）に変更（#14）
- RDS SSL接続設定を追加・修正（#49, #51）
- S3ServiceのAWS認証情報を任意設定に変更（#47）

### レシート機能
- レシート画像アップロード・S3保存機能を実装（#16）
- GPT-4o Visionによるレシート自動解析を実装（#17）
- zodとStructured OutputsによるGPTレスポンスの型安全化とリトライ処理を実装
- レシートアップロードで複数ファイル選択・ローディング表示に対応
- 重複レシート検出機能と重複確認画面を実装

### ダッシュボード・UI
- ダッシュボード・レシート一覧・レシート詳細画面を実装（#19）
- レシート一覧に編集・削除機能を追加
- 月別棒グラフ・カテゴリ別円グラフをダッシュボードに追加

### LLMチャット
- LLMチャット機能（Tool Calling）を実装（#18）

### AWSインフラ・デプロイ
- EC2 + Docker Compose による本番デプロイ構成を実装（#22〜#39）
- npmワークスペース構成を廃止しfrontend/backend独立インストールに変更（#36）
- SSHからSSMセッションマネージャー経由のデプロイに変更（#39）

### nginx
- NestJSに `api/v1` グローバルプレフィックスを追加し名前空間を分離（#44, #45）
- APIプロキシ設定を追加してERR_CONNECTION_REFUSEDを修正（#54, #56）
- nginxコンテナを追加し `client_max_body_size` を15mに設定（#59）
- nginx を完全Docker化しgit管理に移行（#62）
- nginx設定をテンプレート化し `BACKEND_UPSTREAM` を環境変数化（#71）

### バグ修正・改善
- SSMコマンドにgitインストールを追加しgit pullを確実に実行（#66）
- middlewareのmatcherに `api/backend` を除外し、レシート一覧が表示されない問題を修正（#73）
- SSRで `BACKEND_URL` を使用してバックエンドに直接通信するよう修正（#76）
- `BACKEND_URL` のフォールバックURLのハードコーディングを除去（#76）