### PR TITLE
fix: 支出アシスタントが「今月」を2023年10月と誤認する問題を修正 #78

### DIFF
--- a/backend/src/chat/chat.service.ts
+++ b/backend/src/chat/chat.service.ts
@@ -20,10 +20,17 @@ const TOOL_CALLS_MARKER = '__tool_calls__';
 // 無限ループを防ぐためのツール呼び出し上限
 const MAX_TOOL_ITERATIONS = 5;
 
-const SYSTEM_PROMPT = `あなたは家計管理アシスタントです。ユーザーの支出に関する質問に、\
+function buildSystemPrompt(): string {
+  const now = new Date();
+  const year = now.getFullYear();
+  const month = now.getMonth() + 1;
+  const day = now.getDate();
+  return `あなたは家計管理アシスタントです。ユーザーの支出に関する質問に、\
 提供されたツールを使ってデータを取得した上で日本語で回答してください。\
 期間の指定がない場合は from と to を省略して全期間を対象としてください。\
-金額は日本円で表示し、カテゴリ別の内訳も合わせて提示してください。`;
+金額は日本円で表示し、カテゴリ別の内訳も合わせて提示してください。\
+今日の日付は${year}年${month}月${day}日です。「今月」は${year}年${month}月を指します。`;
+}
 
 @Injectable()
 export class ChatService {
@@ -81,7 +88,7 @@ export class ChatService {
     );
 
     const messages: OpenAI.Chat.ChatCompletionMessageParam[] = [
-      { role: 'system', content: SYSTEM_PROMPT },
+      { role: 'system', content: buildSystemPrompt() },
       ...this.toOpenAiMessages(history),
       { role: 'user', content: userMessage },
     ];


### PR DESCRIPTION
## Summary

- `SYSTEM_PROMPT` 定数を `buildSystemPrompt()` 関数に変更し、リクエスト時の現在日時を動的に埋め込む
- GPT がトレーニングデータのカットオフ時点（2023年10月）を「現在」と誤推定する問題を解消
- 「今月」「今年」などの相対的な時間表現を正しく解釈できるようになる

## Test plan

- [ ] チャットで「今月の支出は？」と質問し、現在月（2026年3月）のデータが返ることを確認
- [ ] `get_monthly_summary` ツールに渡される `year` / `month` が正しい値であることをログで確認
- [ ] 過去月指定（「先月の支出は？」等）が引き続き正常動作することを確認

Closes #78

🤖 Generated with [Claude Code](https://claude.com/claude-code)