### PR TITLE
fix: アプリ内ブラウザでのGoogleログインブロック対処

### DIFF
--- a/backend/src/chat/chat.service.ts
+++ b/backend/src/chat/chat.service.ts
@@ -23,13 +23,15 @@ const MAX_TOOL_ITERATIONS = 5;
 function buildSystemPrompt(): string {
   const now = new Date();
   const year = now.getFullYear();
+  // getMonth() は 0-indexed のため +1
   const month = now.getMonth() + 1;
   const day = now.getDate();
+
   return `あなたは家計管理アシスタントです。ユーザーの支出に関する質問に、\
 提供されたツールを使ってデータを取得した上で日本語で回答してください。\
+今日の日付は${year}年${month}月${day}日です。「今月」は${year}年${month}月を指します。\
 期間の指定がない場合は from と to を省略して全期間を対象としてください。\
-金額は日本円で表示し、カテゴリ別の内訳も合わせて提示してください。\
-今日の日付は${year}年${month}月${day}日です。「今月」は${year}年${month}月を指します。`;
+金額は日本円で表示し、カテゴリ別の内訳も合わせて提示してください。`;
 }
 
 @Injectable()

--- a/frontend/src/app/_components/LoginCard.tsx
+++ b/frontend/src/app/_components/LoginCard.tsx
@@ -1,0 +1,64 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+
+type BrowserState = 'loading' | 'normal' | 'android-webview' | 'ios-inapp';
+
+export function LoginCard() {
+  const [browserState, setBrowserState] = useState<BrowserState>('loading');
+
+  useEffect(() => {
+    const ua = navigator.userAgent;
+    const isAndroidWebView = /\bwv\b/.test(ua);
+    const isIosWebView = /iPhone|iPad|iPod/.test(ua) && !/Safari\//.test(ua);
+
+    if (isAndroidWebView) {
+      // intent スキームで Chrome に自動リダイレクト
+      const { host, pathname, search } = location;
+      window.location.href = `intent://${host}${pathname}${search}#Intent;scheme=https;package=com.android.chrome;end`;
+      setBrowserState('android-webview');
+    } else if (isIosWebView) {
+      setBrowserState('ios-inapp');
+    } else {
+      setBrowserState('normal');
+    }
+  }, []);
+
+  return (
+    <div className="flex w-full max-w-sm flex-col items-center gap-8 rounded-2xl bg-white p-8 shadow-sm sm:p-12 dark:bg-zinc-900">
+      <h1 className="text-2xl font-semibold text-zinc-900 dark:text-zinc-50">
+        Credit Checker
+      </h1>
+
+      {browserState === 'loading' && null}
+
+      {browserState === 'android-webview' && (
+        <p className="text-sm text-zinc-500 dark:text-zinc-400">
+          ブラウザを起動しています…
+        </p>
+      )}
+
+      {browserState === 'ios-inapp' && (
+        <div className="flex flex-col gap-3 rounded-xl bg-yellow-50 p-4 text-sm text-yellow-800 dark:bg-yellow-900/30 dark:text-yellow-300">
+          <p className="font-medium">アプリ内ブラウザではGoogleログインが使用できません</p>
+          <p>Safariで開いてから再度ログインしてください。</p>
+          <p className="text-xs">右下の共有ボタン →「Safariで開く」</p>
+        </div>
+      )}
+
+      {browserState === 'normal' && (
+        <>
+          <p className="text-zinc-500 dark:text-zinc-400">
+            レシートを管理して支出を把握しよう
+          </p>
+          <a
+            href="/api/auth/signin/google?callbackUrl=/dashboard"
+            className="flex items-center gap-3 rounded-full bg-zinc-900 px-6 py-3 text-sm font-medium text-white transition-colors hover:bg-zinc-700 dark:bg-zinc-50 dark:text-zinc-900 dark:hover:bg-zinc-200"
+          >
+            Google でログイン
+          </a>
+        </>
+      )}
+    </div>
+  );
+}

--- a/frontend/src/app/page.tsx
+++ b/frontend/src/app/page.tsx
@@ -1,6 +1,6 @@
 import { auth } from '../../auth';
-import { signIn } from '../../auth';
 import { redirect } from 'next/navigation';
+import { LoginCard } from './_components/LoginCard';
 
 export default async function Home() {
   const session = await auth();
@@ -11,27 +11,7 @@ export default async function Home() {
 
   return (
     <div className="flex flex-1 items-center justify-center bg-zinc-50 px-4 dark:bg-black">
-      <div className="flex w-full max-w-sm flex-col items-center gap-8 rounded-2xl bg-white p-8 shadow-sm sm:p-12 dark:bg-zinc-900">
-        <h1 className="text-2xl font-semibold text-zinc-900 dark:text-zinc-50">
-          Credit Checker
-        </h1>
-        <p className="text-zinc-500 dark:text-zinc-400">
-          レシートを管理して支出を把握しよう
-        </p>
-        <form
-          action={async () => {
-            'use server';
-            await signIn('google', { redirectTo: '/dashboard' });
-          }}
-        >
-          <button
-            type="submit"
-            className="flex items-center gap-3 rounded-full bg-zinc-900 px-6 py-3 text-sm font-medium text-white transition-colors hover:bg-zinc-700 dark:bg-zinc-50 dark:text-zinc-900 dark:hover:bg-zinc-200"
-          >
-            Google でログイン
-          </button>
-        </form>
-      </div>
+      <LoginCard />
     </div>
   );
 }


### PR DESCRIPTION
## Summary

- Android WebView（UA に `\bwv\b`）を検出し、intent スキームで Chrome に自動リダイレクト
- iOS アプリ内ブラウザ（`iPhone/iPad/iPod` を含むが `Safari/` を含まない）を検出し、「Safariで開く」手順を案内
- LINE・Instagram・Facebook など任意のアプリ内ブラウザに対応

## Background

LINEなどのアプリ内ブラウザ（WebView）からGoogleログインを試みると `403: disallowed_useragent` が発生する問題をデプロイ環境のスマホから確認。

## Changes

- `frontend/src/app/_components/LoginCard.tsx`（新規）: WebView 検出・分岐 UI を持つ Client Component
- `frontend/src/app/page.tsx`: ログインカード部分を `LoginCard` に委譲
- `backend/src/chat/chat.service.ts`: システムプロンプトのコメント・文言整理

## Related

- #84 PR
- #85 iOS アプリ内ブラウザ対応 Issue（今後の課題）

## Test plan

- [ ] 通常ブラウザ（Chrome/Safari）でアクセスし、Google ログインボタンが表示されること
- [ ] Android アプリ内ブラウザでアクセスし、Chrome に自動リダイレクトされること
- [ ] iOS アプリ内ブラウザでアクセスし、「Safariで開く」案内が表示されること

🤖 Generated with [Claude Code](https://claude.com/claude-code)