### PR TITLE
fix: Server ActionでサインインしAuth.js UnknownActionエラーを修正 #87

### DIFF
--- a/frontend/src/app/_components/LoginCard.tsx
+++ b/frontend/src/app/_components/LoginCard.tsx
@@ -4,7 +4,11 @@ import { useEffect, useState } from 'react';
 
 type BrowserState = 'loading' | 'normal' | 'android-webview' | 'ios-inapp';
 
-export function LoginCard() {
+type Props = {
+  signIn: () => Promise<void>;
+};
+
+export function LoginCard({ signIn }: Props) {
   const [browserState, setBrowserState] = useState<BrowserState>('loading');
 
   useEffect(() => {
@@ -51,12 +55,14 @@ export function LoginCard() {
           <p className="text-zinc-500 dark:text-zinc-400">
             レシートを管理して支出を把握しよう
           </p>
-          <a
-            href="/api/auth/signin/google?callbackUrl=/dashboard"
-            className="flex items-center gap-3 rounded-full bg-zinc-900 px-6 py-3 text-sm font-medium text-white transition-colors hover:bg-zinc-700 dark:bg-zinc-50 dark:text-zinc-900 dark:hover:bg-zinc-200"
-          >
-            Google でログイン
-          </a>
+          <form action={signIn}>
+            <button
+              type="submit"
+              className="flex items-center gap-3 rounded-full bg-zinc-900 px-6 py-3 text-sm font-medium text-white transition-colors hover:bg-zinc-700 dark:bg-zinc-50 dark:text-zinc-900 dark:hover:bg-zinc-200"
+            >
+              Google でログイン
+            </button>
+          </form>
         </>
       )}
     </div>

--- a/frontend/src/app/page.tsx
+++ b/frontend/src/app/page.tsx
@@ -1,4 +1,4 @@
-import { auth } from '../../auth';
+import { auth, signIn } from '../../auth';
 import { redirect } from 'next/navigation';
 import { LoginCard } from './_components/LoginCard';
 
@@ -9,9 +9,14 @@ export default async function Home() {
     redirect('/dashboard');
   }
 
+  const handleSignIn = async () => {
+    'use server';
+    await signIn('google', { redirectTo: '/dashboard' });
+  };
+
   return (
     <div className="flex flex-1 items-center justify-center bg-zinc-50 px-4 dark:bg-black">
-      <LoginCard />
+      <LoginCard signIn={handleSignIn} />
     </div>
   );
 }


### PR DESCRIPTION
## 概要

PR #84 で導入したログインボタンの変更（`<a>` タグ）が原因で、全ブラウザでGoogleログインが失敗していた問題を修正します。

closes #87

## 原因

Auth.js v5 は signin に **POST リクエスト**が必要ですが、`<a href="/api/auth/signin/google">` は **GET リクエスト**を送るため `UnknownAction` エラーになっていました。

## 変更内容

### `frontend/src/app/page.tsx`
- `signIn` Server Action を定義し、`LoginCard` に prop として渡す

### `frontend/src/app/_components/LoginCard.tsx`
- `signIn` prop を受け取る
- `<a>` タグ → `<form action={signIn}>` + `<button>` に変更（POST リクエストに戻す）
- Android の Chrome リダイレクト（intent スキーム）はそのまま維持

## テスト手順

- [ ] 通常ブラウザ（PC Chrome / Safari）でGoogleログインが成功する
- [ ] Android アプリ内ブラウザから Chrome へリダイレクト後、ログインが成功する
- [ ] iOS アプリ内ブラウザで手動案内UIが表示される

🤖 Generated with [Claude Code](https://claude.com/claude-code)