### PR TITLE
fix: deploy.yml の secrets フィールドで needs.* 参照による startup_failure を修正 #120

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -33,25 +33,50 @@ jobs:
             echo "name=dev" >> "$GITHUB_OUTPUT"
           fi
 
-  # インフラデプロイ（infra/ に変更がある場合のみ）
-  deploy-infra:
+  # インフラデプロイ - dev（infra/ に変更がある場合のみ）
+  deploy-infra-dev:
     needs: detect-changes
-    if: needs.detect-changes.outputs.infra == 'true'
+    if: needs.detect-changes.outputs.infra == 'true' && needs.detect-changes.outputs.env == 'dev'
     uses: ./.github/workflows/reusable-infra-deploy.yml
     with:
-      environment: ${{ needs.detect-changes.outputs.env }}
+      environment: dev
     secrets:
-      aws_account_id: ${{ needs.detect-changes.outputs.env == 'prod' && secrets.PROD_AWS_ACCOUNT_ID || secrets.DEV_AWS_ACCOUNT_ID }}
+      aws_account_id: ${{ secrets.DEV_AWS_ACCOUNT_ID }}
 
-  # アプリデプロイ（apps/ に変更がある場合のみ、infra デプロイの後に実行）
-  deploy-app:
-    needs: [detect-changes, deploy-infra]
+  # インフラデプロイ - prod（infra/ に変更がある場合のみ）
+  deploy-infra-prod:
+    needs: detect-changes
+    if: needs.detect-changes.outputs.infra == 'true' && needs.detect-changes.outputs.env == 'prod'
+    uses: ./.github/workflows/reusable-infra-deploy.yml
+    with:
+      environment: prod
+    secrets:
+      aws_account_id: ${{ secrets.PROD_AWS_ACCOUNT_ID }}
+
+  # アプリデプロイ - dev（apps/ に変更がある場合のみ、infra デプロイの後に実行）
+  deploy-app-dev:
+    needs: [detect-changes, deploy-infra-dev]
     if: |
       always() &&
       needs.detect-changes.outputs.apps == 'true' &&
-      (needs.deploy-infra.result == 'success' || needs.deploy-infra.result == 'skipped')
+      needs.detect-changes.outputs.env == 'dev' &&
+      (needs.deploy-infra-dev.result == 'success' || needs.deploy-infra-dev.result == 'skipped')
     uses: ./.github/workflows/reusable-app-deploy.yml
     with:
-      environment: ${{ needs.detect-changes.outputs.env }}
+      environment: dev
     secrets:
-      aws_account_id: ${{ needs.detect-changes.outputs.env == 'prod' && secrets.PROD_AWS_ACCOUNT_ID || secrets.DEV_AWS_ACCOUNT_ID }}
+      aws_account_id: ${{ secrets.DEV_AWS_ACCOUNT_ID }}
+
+  # アプリデプロイ - prod（apps/ に変更がある場合のみ、infra デプロイの後に実行）
+  deploy-app-prod:
+    needs: [detect-changes, deploy-infra-prod]
+    if: |
+      always() &&
+      needs.detect-changes.outputs.apps == 'true' &&
+      needs.detect-changes.outputs.env == 'prod' &&
+      (needs.deploy-infra-prod.result == 'success' || needs.deploy-infra-prod.result == 'skipped')
+    uses: ./.github/workflows/reusable-app-deploy.yml
+    with:
+      environment: prod
+    secrets:
+      aws_account_id: ${{ secrets.PROD_AWS_ACCOUNT_ID }}


### PR DESCRIPTION
## Summary

- `deploy.yml` で reusable workflow の `secrets:` フィールドに `needs.detect-changes.outputs.env` を参照する式を使用していたため、GitHub Actions の制約により `startup_failure` が発生していた
- `deploy-infra` と `deploy-app` ジョブを dev/prod に分岐し、各環境に対応する secret を直接渡すよう修正
- dev ジョブは `DEV_AWS_ACCOUNT_ID` のみ、prod ジョブは `PROD_AWS_ACCOUNT_ID` のみにアクセスでき、最小権限の原則に準拠

Closes #120

## Test plan

- [ ] develop へのマージ後に Deploy ワークフローが `startup_failure` なく起動することを確認
- [ ] `apps/**` または `infra/**` 変更時に dev ジョブのみが実行されることを確認
- [ ] main へのマージ後に prod ジョブのみが実行されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)