### PR TITLE
fix: deploy.yml に OIDC 用 permissions を追加し startup_failure を解消 #120

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -4,6 +4,11 @@ on:
   push:
     branches: [develop, main]
 
+# reusable workflow が OIDC (id-token: write) を使うため、呼び出し側でも明示が必要
+permissions:
+  id-token: write
+  contents: read
+
 jobs:
   # 変更箇所の検知
   detect-changes:


### PR DESCRIPTION
## Summary

- reusable workflow (`reusable-infra-deploy.yml`, `reusable-app-deploy.yml`) で OIDC (`id-token: write`) を使用しているが、GitHub Actions の仕様により**呼び出し側の workflow にも `id-token: write` の明示が必要**
- この権限が欠落していたため `startup_failure` が発生していた
- `deploy.yml` の workflow レベルに `permissions: id-token: write` と `contents: read` を追加して修正

Closes #120

## 根拠

旧 deploy.yml（EC2 ベース、正常動作していた）は各ジョブに `permissions: id-token: write` を明示していた。ECS ベースに刷新した際、permissions を reusable workflow 側に移したが、呼び出し側への明示も必要というGitHub の要件を満たせていなかった。

## Test plan

- [ ] develop へのマージ後に Deploy ワークフローが `startup_failure` なく起動することを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)