### PR TITLE
feat: GitHub Actions OIDC プロバイダーと deploy ロールを CDK で管理する BootstrapStack を追加 #125

### DIFF
--- a/infra/bin/app.ts
+++ b/infra/bin/app.ts
@@ -2,6 +2,7 @@
 import * as cdk from 'aws-cdk-lib';
 import { devConfig } from '../config/dev';
 import { prodConfig } from '../config/prod';
+import { BootstrapStack } from '../lib/bootstrap/bootstrap-stack';
 import { NetworkStack } from '../lib/network/network-stack';
 import { DataStack } from '../lib/data/data-stack';
 import { AppStack } from '../lib/app/app-stack';
@@ -13,6 +14,14 @@ const config = targetEnv === 'prod' ? prodConfig : devConfig;
 
 const appName = app.node.tryGetContext('appName') as string | undefined;
 if (!appName) throw new Error('CDK context "appName" is required. Pass -c appName=<name>');
+
+// GitHub Actions OIDC プロバイダーと deploy ロールを管理するスタック
+// 初回のみローカルの AWS 認証情報で手動実行が必要:
+//   npx cdk deploy Bootstrap -c env=dev -c appName=<name>
+new BootstrapStack(app, 'Bootstrap', {
+  githubRepo: 'jun-eg/credit-checker',
+  env: config.env,
+});
 
 const network = new NetworkStack(app, `${config.envName}Network`, {
   config,

--- a/infra/lib/app/app-stack.ts
+++ b/infra/lib/app/app-stack.ts
@@ -59,7 +59,7 @@ export class AppStack extends cdk.Stack {
       }),
     );
 
-    // github-actions-deploy-roleはCDK外で管理されているためfromRoleArnで参照
+    // github-actions-deploy-roleはBootstrapStackで管理されているためfromRoleArnで参照
     const deployRole = iam.Role.fromRoleArn(
       this,
       'DeployRole',

--- a/infra/lib/bootstrap/bootstrap-stack.ts
+++ b/infra/lib/bootstrap/bootstrap-stack.ts
@@ -1,0 +1,39 @@
+import * as cdk from 'aws-cdk-lib';
+import * as iam from 'aws-cdk-lib/aws-iam';
+import { Construct } from 'constructs';
+
+interface BootstrapStackProps extends cdk.StackProps {
+  githubRepo: string; // 例: 'jun-eg/credit-checker'
+}
+
+export class BootstrapStack extends cdk.Stack {
+  constructor(scope: Construct, id: string, props: BootstrapStackProps) {
+    super(scope, id, props);
+
+    const { githubRepo } = props;
+
+    // GitHub Actions の OIDC プロバイダー（アカウントに1つ）
+    const oidcProvider = new iam.OpenIdConnectProvider(this, 'GitHubOidcProvider', {
+      url: 'https://token.actions.githubusercontent.com',
+      clientIds: ['sts.amazonaws.com'],
+    });
+
+    // GitHub Actions デプロイロール
+    // CDK デプロイ（CloudFormation・IAM・VPC・RDS 等）を含む全操作が必要なため AdministratorAccess を付与
+    new iam.Role(this, 'DeployRole', {
+      roleName: 'github-actions-deploy-role',
+      assumedBy: new iam.WebIdentityPrincipal(oidcProvider.openIdConnectProviderArn, {
+        StringEquals: {
+          'token.actions.githubusercontent.com:aud': 'sts.amazonaws.com',
+        },
+        StringLike: {
+          // 特定リポジトリからの assume のみ許可
+          'token.actions.githubusercontent.com:sub': `repo:${githubRepo}:*`,
+        },
+      }),
+      managedPolicies: [
+        iam.ManagedPolicy.fromAwsManagedPolicyName('AdministratorAccess'),
+      ],
+    });
+  }
+}


### PR DESCRIPTION
## Summary

- `infra/lib/bootstrap/bootstrap-stack.ts` を新規作成
  - GitHub Actions OIDC プロバイダー（`token.actions.githubusercontent.com`）
  - `github-actions-deploy-role` IAM ロール（`AdministratorAccess` 付与）
- `infra/bin/app.ts` に `BootstrapStack` を追加
- `app-stack.ts` のコメントを更新（CDK外 → BootstrapStack管理）

Closes #125

## 初回デプロイ手順

マージ後、ローカルの AWS 認証情報（dev アカウント権限あり）で以下を1回だけ実行してください：

```bash
cd infra
npm ci
npx cdk deploy Bootstrap -c env=dev -c appName=credit-checker
```

完了後は GitHub Actions の Deploy ワークフローを手動実行（`workflow_dispatch`）でフルデプロイできます。

## Test plan

- [ ] `npx cdk deploy Bootstrap -c env=dev -c appName=credit-checker` が成功することを確認
- [ ] AWS Console で OIDC プロバイダーと `github-actions-deploy-role` が作成されていることを確認
- [ ] GitHub Actions の Deploy ワークフローが OIDC 認証に成功することを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)