### PR TITLE
fix: FargateSgにNameタグを追加しECSデプロイ時のSG検索失敗を修正 #132

### DIFF
--- a/.github/workflows/reusable-app-deploy.yml
+++ b/.github/workflows/reusable-app-deploy.yml
@@ -119,7 +119,7 @@ jobs:
             --filters 'Name=tag:Name,Values=*Public*' \
             --query 'Subnets[0].SubnetId' --output text)
           SG_ID=$(aws ec2 describe-security-groups \
-            --filters 'Name=tag:Name,Values=*FargateSg*' \
+            --filters "Name=tag:Name,Values=${{ vars.APP_NAME }}-FargateSg-${{ inputs.environment }}" \
             --query 'SecurityGroups[0].GroupId' --output text)
 
           TASK_ARN=$(aws ecs run-task \

--- a/infra/bin/app.ts
+++ b/infra/bin/app.ts
@@ -46,6 +46,7 @@ new BootstrapStack(app, 'Bootstrap', {
 });
 
 const network = new NetworkStack(app, `${config.envName}Network`, {
+  appName,
   config,
   env: config.env,
 });

--- a/infra/lib/network/network-stack.ts
+++ b/infra/lib/network/network-stack.ts
@@ -4,6 +4,7 @@ import { Construct } from 'constructs';
 import { EnvironmentConfig } from '../../config';
 
 interface NetworkStackProps extends cdk.StackProps {
+  appName: string;
   config: EnvironmentConfig;
 }
 
@@ -16,7 +17,7 @@ export class NetworkStack extends cdk.Stack {
   constructor(scope: Construct, id: string, props: NetworkStackProps) {
     super(scope, id, props);
 
-    const { config } = props;
+    const { appName, config } = props;
 
     this.vpc = new ec2.Vpc(this, 'Vpc', {
       maxAzs: config.vpc.maxAzs,
@@ -53,6 +54,9 @@ export class NetworkStack extends cdk.Stack {
       // 最小権限：明示的に許可したアウトバウンドのみ許可
       allowAllOutbound: false,
     });
+    // CDKはSGにNameタグを自動付与しないため明示的に設定する
+    // 同一アカウントに複数アプリが共存する構成のためappNameで識別する
+    cdk.Tags.of(this.fargateSecurityGroup).add('Name', `${appName}-FargateSg-${config.envName.toLowerCase()}`);
     // ALB からのトラフィックのみ受け入れる（frontend / backend のアプリポートに限定）
     this.fargateSecurityGroup.addIngressRule(
       ec2.Peer.securityGroupId(this.albSecurityGroup.securityGroupId),

--- a/infra/test/app.test.ts
+++ b/infra/test/app.test.ts
@@ -11,6 +11,7 @@ const TEST_APP_NAME = 'test-app';
 function buildAppTemplate(config: typeof devConfig) {
   const app = new cdk.App();
   const network = new NetworkStack(app, `${config.envName}Network`, {
+    appName: TEST_APP_NAME,
     config,
     env: config.env,
   });

--- a/infra/test/data.test.ts
+++ b/infra/test/data.test.ts
@@ -10,6 +10,7 @@ const TEST_APP_NAME = 'test-app';
 function buildDataTemplate(config: typeof devConfig) {
   const app = new cdk.App();
   const network = new NetworkStack(app, `${config.envName}Network`, {
+    appName: TEST_APP_NAME,
     config,
     env: config.env,
   });

--- a/infra/test/network.test.ts
+++ b/infra/test/network.test.ts
@@ -9,6 +9,7 @@ describe('NetworkStack', () => {
   beforeAll(() => {
     const app = new cdk.App();
     const stack = new NetworkStack(app, 'TestNetwork', {
+      appName: 'test-app',
       config: devConfig,
       env: devConfig.env,
     });


### PR DESCRIPTION
## Summary
- `NetworkStack` に `appName` プロパティを追加し、FargateSgに `${appName}-FargateSg-${envName}` 形式の `Name` タグを明示的に付与
- CDKは `ec2.SecurityGroup` に `Name` タグを自動付与しないため、ワークフローのフィルターが `None` を返していた
- 同一AWSアカウントに複数アプリのdev/prodが共存する構成のため `appName` による識別が必要
- ワークフロー側のフィルターも `${{ vars.APP_NAME }}-FargateSg-${{ inputs.environment }}` に更新

Closes #132

## Test plan
- [ ] CDK diff で FargateSg に `Name` タグが追加されることを確認
- [ ] dev環境へのデプロイでマイグレーションタスクが正常に起動することを確認