### PR TITLE
fix: CloudFront→ALB経由のServer Action CSRF 403エラーを修正 #137

### DIFF
--- a/apps/frontend/next.config.ts
+++ b/apps/frontend/next.config.ts
@@ -2,6 +2,11 @@ import type { NextConfig } from 'next';
 
 const nextConfig: NextConfig = {
   output: 'standalone',
+  // CloudFront → ALB 経由だと Host ヘッダーが ALB の DNS 名に書き換わり
+  // Next.js の Server Action CSRF チェックが 403 を返すため許可ドメインを明示する
+  serverActions: {
+    allowedOrigins: ['dev.jun-eg.site', 'jun-eg.site'],
+  },
   async rewrites() {
     // 本番は ALB がルーティングするため不要
     // ローカル開発時（npm run dev）は NEXT_PUBLIC_BACKEND_URL に転送


### PR DESCRIPTION
## 概要

closes #137

CloudFront → ALB 経由でリクエストが届く際、`Host` ヘッダーが ALB の DNS 名に書き換わり、Next.js の Server Action CSRF チェックが 403 を返す問題を修正する。

## 変更内容

- `apps/frontend/next.config.ts` に `serverActions.allowedOrigins` を追加
  - `dev.jun-eg.site`（dev環境）と `jun-eg.site`（本番環境）を許可ドメインとして明示

## 原因

Next.js の Server Action は `Origin` ヘッダーと `Host` ヘッダーを比較して CSRF を防止する。CloudFront → ALB 構成では Host ヘッダーが ALB の内部 DNS 名に書き換わるため、オリジンと一致せず 403 が発生する。`allowedOrigins` に実際のドメインを指定することで解消する。

## テスト計画

- [ ] dev環境（dev.jun-eg.site）でServer Actionが正常に動作することを確認
- [ ] 本番環境（jun-eg.site）でServer Actionが正常に動作することを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)