### PR TITLE
fix: next.config.ts の serverActions を experimental 配下に修正 #137

### DIFF
--- a/apps/frontend/next.config.ts
+++ b/apps/frontend/next.config.ts
@@ -2,10 +2,12 @@ import type { NextConfig } from 'next';
 
 const nextConfig: NextConfig = {
   output: 'standalone',
-  // CloudFront → ALB 経由だと Host ヘッダーが ALB の DNS 名に書き換わり
-  // Next.js の Server Action CSRF チェックが 403 を返すため許可ドメインを明示する
-  serverActions: {
-    allowedOrigins: ['dev.jun-eg.site', 'jun-eg.site'],
+  experimental: {
+    // CloudFront → ALB 経由だと Host ヘッダーが ALB の DNS 名に書き換わり
+    // Next.js の Server Action CSRF チェックが 403 を返すため許可ドメインを明示する
+    serverActions: {
+      allowedOrigins: ['dev.jun-eg.site', 'jun-eg.site'],
+    },
   },
   async rewrites() {
     // 本番は ALB がルーティングするため不要


### PR DESCRIPTION
## Summary

- `apps/frontend/next.config.ts` の `serverActions` を `experimental` 配下に移動
- Next.js 15以降では `experimental.serverActions` が正しい配置であるため修正

## Related Issue

Closes #137

## Test plan

- [ ] フロントエンドのビルドが正常に通ること
- [ ] Server Actions が正常に動作すること（CSRF チェックが通ること）

🤖 Generated with [Claude Code](https://claude.com/claude-code)