### PR TITLE
fix: CloudFrontのallowedMethodsにALLOW_ALLを追加 #140

### DIFF
--- a/infra/lib/edge/edge-stack.ts
+++ b/infra/lib/edge/edge-stack.ts
@@ -105,6 +105,8 @@ export class EdgeStack extends cdk.Stack {
         viewerProtocolPolicy: cloudfront.ViewerProtocolPolicy.REDIRECT_TO_HTTPS,
         cachePolicy: cloudfront.CachePolicy.CACHING_DISABLED,
         originRequestPolicy: cloudfront.OriginRequestPolicy.ALL_VIEWER,
+        // Next.js Server Action は POST を使用するため ALL を許可する
+        allowedMethods: cloudfront.AllowedMethods.ALLOW_ALL,
       },
       domainNames: [config.domain],
       certificate,


### PR DESCRIPTION
## 概要

- `infra/lib/edge/edge-stack.ts` の CloudFront `defaultBehavior` に `allowedMethods: cloudfront.AllowedMethods.ALLOW_ALL` を追加

## 変更理由

Next.js Server Action は POST リクエストを使用するが、CloudFront のデフォルト設定では GET/HEAD のみ許可されている。そのため Server Action のリクエストが 403 エラーになっていた。`ALLOW_ALL` を設定することで POST リクエストを CloudFront が通過させるようにする。

## 関連 Issue

Closes #140