### PR TITLE
fix: ALBバックエンドルーティングを/api/*から/api/v1/*に修正 #142

### DIFF
--- a/infra/lib/edge/edge-stack.ts
+++ b/infra/lib/edge/edge-stack.ts
@@ -60,7 +60,7 @@ export class EdgeStack extends cdk.Stack {
       defaultAction: elbv2.ListenerAction.fixedResponse(404),
     });
 
-    // /api/* → backend
+    // /api/v1/* → backend（/api/auth/* 等の Next.js ルートを誤ってバックエンドに転送しないよう v1 に限定）
     const backendTargetGroup = new elbv2.ApplicationTargetGroup(this, 'BackendTg', {
       vpc,
       port: ports.backend,
@@ -74,7 +74,7 @@ export class EdgeStack extends cdk.Stack {
 
     httpsListener.addAction('BackendAction', {
       priority: 10,
-      conditions: [elbv2.ListenerCondition.pathPatterns(['/api/*'])],
+      conditions: [elbv2.ListenerCondition.pathPatterns(['/api/v1/*'])],
       action: elbv2.ListenerAction.forward([backendTargetGroup]),
     });
 


### PR DESCRIPTION
## 概要

- `infra/lib/edge/edge-stack.ts` のALBリスナールールにおけるバックエンドルーティングのパスパターンを `/api/*` から `/api/v1/*` に変更

## 変更理由

`/api/*` のままだと `/api/auth/*` 等の Next.js が処理すべきルートもバックエンドに転送されてしまう。バックエンドAPIのパスを `/api/v1/*` に限定することで、誤ったルーティングを防ぐ。

## 変更ファイル

- `infra/lib/edge/edge-stack.ts`
  - `BackendAction` のパスパターンを `/api/*` → `/api/v1/*` に変更
  - コメントを更新

## テスト計画

- [ ] CDK diff で意図したリスナールール変更のみが出力されることを確認
- [ ] デプロイ後、`/api/v1/` 以下のエンドポイントがバックエンドに正常ルーティングされることを確認
- [ ] `/api/auth/` 等のNext.jsルートがバックエンドに転送されないことを確認

Closes #142

🤖 Generated with [Claude Code](https://claude.com/claude-code)