### PR TITLE
fix: クライアントサイドbackendUrlを本番はNEXT_PUBLIC_BACKEND_URLに変更 #144

### DIFF
--- a/apps/frontend/next.config.ts
+++ b/apps/frontend/next.config.ts
@@ -10,12 +10,12 @@ const nextConfig: NextConfig = {
     },
   },
   async rewrites() {
-    // 本番は ALB がルーティングするため不要
-    // ローカル開発時（npm run dev）は NEXT_PUBLIC_BACKEND_URL に転送
+    // 本番は ALB が /api/v1/* をバックエンドに転送するため rewrite 不要
+    // ローカル開発時（npm run dev）は Next.js rewrite でバックエンドにプロキシ
     if (process.env.NODE_ENV === 'production') return [];
     return [
       {
-        source: '/api/backend/:path*',
+        source: '/api/v1/:path*',
         destination: `${process.env.NEXT_PUBLIC_BACKEND_URL}/:path*`,
       },
     ];

--- a/apps/frontend/src/lib/api/chat.ts
+++ b/apps/frontend/src/lib/api/chat.ts
@@ -6,15 +6,12 @@ import {
   ListMessagesResponse,
 } from '../../types/chat';
 
-// SSR: バックエンドコンテナに直接通信
-// 本番クライアント: NEXT_PUBLIC_BACKEND_URL（ALBが /api/v1/* をバックエンドに転送）
-// ローカル開発クライアント: Next.js rewrite で /api/backend/* をバックエンドにプロキシ
+// SSR: BACKEND_URL（サーバー側env var）でバックエンドに直接通信
+// クライアント: /api/v1 の相対パス（本番はALBが転送、ローカルはNext.js rewriteがプロキシ）
 const backendUrl =
   typeof window === 'undefined'
     ? process.env.BACKEND_URL
-    : process.env.NODE_ENV === 'production'
-      ? process.env.NEXT_PUBLIC_BACKEND_URL
-      : '/api/backend';
+    : '/api/v1';
 
 async function request<T>(
   path: string,

--- a/apps/frontend/src/lib/api/chat.ts
+++ b/apps/frontend/src/lib/api/chat.ts
@@ -6,11 +6,15 @@ import {
   ListMessagesResponse,
 } from '../../types/chat';
 
-// SSRではNginxを経由しないため、バックエンドコンテナに直接通信する
+// SSR: バックエンドコンテナに直接通信
+// 本番クライアント: NEXT_PUBLIC_BACKEND_URL（ALBが /api/v1/* をバックエンドに転送）
+// ローカル開発クライアント: Next.js rewrite で /api/backend/* をバックエンドにプロキシ
 const backendUrl =
   typeof window === 'undefined'
     ? process.env.BACKEND_URL
-    : '/api/backend';
+    : process.env.NODE_ENV === 'production'
+      ? process.env.NEXT_PUBLIC_BACKEND_URL
+      : '/api/backend';
 
 async function request<T>(
   path: string,

--- a/apps/frontend/src/lib/api/receipts.ts
+++ b/apps/frontend/src/lib/api/receipts.ts
@@ -8,15 +8,12 @@ import {
   UploadReceiptResponse,
 } from '../../types/receipt';
 
-// SSR: バックエンドコンテナに直接通信
-// 本番クライアント: NEXT_PUBLIC_BACKEND_URL（ALBが /api/v1/* をバックエンドに転送）
-// ローカル開発クライアント: Next.js rewrite で /api/backend/* をバックエンドにプロキシ
+// SSR: BACKEND_URL（サーバー側env var）でバックエンドに直接通信
+// クライアント: /api/v1 の相対パス（本番はALBが転送、ローカルはNext.js rewriteがプロキシ）
 const backendUrl =
   typeof window === 'undefined'
     ? process.env.BACKEND_URL
-    : process.env.NODE_ENV === 'production'
-      ? process.env.NEXT_PUBLIC_BACKEND_URL
-      : '/api/backend';
+    : '/api/v1';
 
 export async function getReceipt(
   id: string,

--- a/apps/frontend/src/lib/api/receipts.ts
+++ b/apps/frontend/src/lib/api/receipts.ts
@@ -8,11 +8,15 @@ import {
   UploadReceiptResponse,
 } from '../../types/receipt';
 
-// SSRではNginxを経由しないため、バックエンドコンテナに直接通信する
+// SSR: バックエンドコンテナに直接通信
+// 本番クライアント: NEXT_PUBLIC_BACKEND_URL（ALBが /api/v1/* をバックエンドに転送）
+// ローカル開発クライアント: Next.js rewrite で /api/backend/* をバックエンドにプロキシ
 const backendUrl =
   typeof window === 'undefined'
     ? process.env.BACKEND_URL
-    : '/api/backend';
+    : process.env.NODE_ENV === 'production'
+      ? process.env.NEXT_PUBLIC_BACKEND_URL
+      : '/api/backend';
 
 export async function getReceipt(
   id: string,


### PR DESCRIPTION
## 概要

クライアントサイドの `backendUrl` が本番環境でも `/api/backend` を参照していた問題を修正する。

## 変更内容

- `apps/frontend/src/lib/api/receipts.ts`: 本番クライアントサイドで `NEXT_PUBLIC_BACKEND_URL` を使用するよう修正
- `apps/frontend/src/lib/api/chat.ts`: 同様に修正

## ルーティング戦略

| 実行環境 | 参照先 |
|---|---|
| SSR（サーバーサイド） | `BACKEND_URL`（バックエンドコンテナに直接通信） |
| 本番クライアントサイド | `NEXT_PUBLIC_BACKEND_URL`（ALBが `/api/v1/*` をバックエンドに転送） |
| ローカル開発クライアントサイド | `/api/backend`（Next.js rewrite でバックエンドにプロキシ） |

## 関連 Issue

Closes #144