### PR TITLE
fix: RechartsのSSRを無効化しReact #418ハイドレーションミスマッチを修正 #146

### DIFF
--- a/apps/frontend/src/components/CategoryBarChart.tsx
+++ b/apps/frontend/src/components/CategoryBarChart.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useState, useEffect } from 'react';
+import { useSyncExternalStore } from 'react';
 import { PieChart, Pie, Tooltip, Legend, ResponsiveContainer } from 'recharts';
 import type { PieLabelRenderProps, TooltipContentProps } from 'recharts';
 import type { ValueType, NameType } from 'recharts/types/component/DefaultTooltipContent';
@@ -66,9 +66,12 @@ function CustomTooltip({
   );
 }
 
+// useSyncExternalStore でサーバー/クライアントを区別する（useEffect+setState は lint 非推奨）
+const emptySubscribe = () => () => {};
+
 export function CategoryBarChart({ data, currency }: CategoryBarChartProps) {
-  const [mounted, setMounted] = useState(false);
-  useEffect(() => { setMounted(true); }, []);
+  // サーバー: false、クライアント: true を返す。ハイドレーション時は両者が一致する
+  const isClient = useSyncExternalStore(emptySubscribe, () => true, () => false);
 
   if (data.length === 0) {
     return (
@@ -77,7 +80,7 @@ export function CategoryBarChart({ data, currency }: CategoryBarChartProps) {
   }
 
   // Recharts は SSR でハイドレーションミスマッチを起こすため、クライアントのみでレンダリング
-  if (!mounted) return <div className="h-80" />;
+  if (!isClient) return <div className="h-80" />;
 
   const chartData = data.map((item, i) => ({
     name: item.category,

--- a/apps/frontend/src/components/CategoryBarChart.tsx
+++ b/apps/frontend/src/components/CategoryBarChart.tsx
@@ -1,5 +1,6 @@
 'use client';
 
+import { useState, useEffect } from 'react';
 import { PieChart, Pie, Tooltip, Legend, ResponsiveContainer } from 'recharts';
 import type { PieLabelRenderProps, TooltipContentProps } from 'recharts';
 import type { ValueType, NameType } from 'recharts/types/component/DefaultTooltipContent';
@@ -66,11 +67,17 @@ function CustomTooltip({
 }
 
 export function CategoryBarChart({ data, currency }: CategoryBarChartProps) {
+  const [mounted, setMounted] = useState(false);
+  useEffect(() => { setMounted(true); }, []);
+
   if (data.length === 0) {
     return (
       <p className="text-sm text-zinc-400 dark:text-zinc-600">データがありません</p>
     );
   }
+
+  // Recharts は SSR でハイドレーションミスマッチを起こすため、クライアントのみでレンダリング
+  if (!mounted) return <div className="h-80" />;
 
   const chartData = data.map((item, i) => ({
     name: item.category,

--- a/apps/frontend/src/components/MonthlyBarChart.tsx
+++ b/apps/frontend/src/components/MonthlyBarChart.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useState, useEffect } from 'react';
+import { useSyncExternalStore } from 'react';
 import {
   BarChart,
   Bar,
@@ -91,12 +91,15 @@ function CustomTooltip({
   );
 }
 
+// useSyncExternalStore でサーバー/クライアントを区別する（useEffect+setState は lint 非推奨）
+const emptySubscribe = () => () => {};
+
 export function MonthlyBarChart({ data, currency }: MonthlyBarChartProps) {
-  const [mounted, setMounted] = useState(false);
-  useEffect(() => { setMounted(true); }, []);
+  // サーバー: false、クライアント: true を返す。ハイドレーション時は両者が一致する
+  const isClient = useSyncExternalStore(emptySubscribe, () => true, () => false);
 
   // Recharts は SSR でハイドレーションミスマッチを起こすため、クライアントのみでレンダリング
-  if (!mounted) return <div className="h-[280px]" />;
+  if (!isClient) return <div className="h-[280px]" />;
 
   // カテゴリ一覧（年間合計順に並べる）
   const categoryTotals = new Map<string, number>();

--- a/apps/frontend/src/components/MonthlyBarChart.tsx
+++ b/apps/frontend/src/components/MonthlyBarChart.tsx
@@ -1,5 +1,6 @@
 'use client';
 
+import { useState, useEffect } from 'react';
 import {
   BarChart,
   Bar,
@@ -91,6 +92,12 @@ function CustomTooltip({
 }
 
 export function MonthlyBarChart({ data, currency }: MonthlyBarChartProps) {
+  const [mounted, setMounted] = useState(false);
+  useEffect(() => { setMounted(true); }, []);
+
+  // Recharts は SSR でハイドレーションミスマッチを起こすため、クライアントのみでレンダリング
+  if (!mounted) return <div className="h-[280px]" />;
+
   // カテゴリ一覧（年間合計順に並べる）
   const categoryTotals = new Map<string, number>();
   for (const row of data) {


### PR DESCRIPTION
## Summary
- `CategoryBarChart` と `MonthlyBarChart` に `useState`/`useEffect` による `mounted` ガードを追加
- `mounted` が `false` の間（SSR・初回ハイドレーション時）はプレースホルダー `div` を返し、Recharts を描画しない
- クライアントで `useEffect` が実行された後のみ Recharts をレンダリングすることでハイドレーションミスマッチを解消

## Root Cause
Recharts の `ResponsiveContainer` など一部コンポーネントが SSR とクライアントで異なる DOM（テキストノードを含む）を生成するため、Next.js のハイドレーション時に React error #418 が発生していた。

## Test plan
- [ ] ダッシュボードページでコンソールエラーが出なくなること
- [ ] チャートがクライアントで正常に表示されること

Closes #146

🤖 Generated with [Claude Code](https://claude.com/claude-code)