### PR TITLE
perf: S3 Presigned URLに移行し画像読み込みを高速化 #99

### DIFF
--- a/apps/backend/package-lock.json
+++ b/apps/backend/package-lock.json
@@ -10,6 +10,7 @@
       "license": "UNLICENSED",
       "dependencies": {
         "@aws-sdk/client-s3": "^3.1018.0",
+        "@aws-sdk/s3-request-presigner": "^3.1022.0",
         "@nestjs/common": "^11.0.1",
         "@nestjs/config": "^4.0.3",
         "@nestjs/core": "^11.0.1",
@@ -470,19 +471,19 @@
       }
     },
     "node_modules/@aws-sdk/core": {
-      "version": "3.973.25",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/core/-/core-3.973.25.tgz",
-      "integrity": "sha512-TNrx7eq6nKNOO62HWPqoBqPLXEkW6nLZQGwjL6lq1jZtigWYbK1NbCnT7mKDzbLMHZfuOECUt3n6CzxjUW9HWQ==",
+      "version": "3.973.26",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/core/-/core-3.973.26.tgz",
+      "integrity": "sha512-A/E6n2W42ruU+sfWk+mMUOyVXbsSgGrY3MJ9/0Az5qUdG67y8I6HYzzoAa+e/lzxxl1uCYmEL6BTMi9ZiZnplQ==",
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-sdk/types": "^3.973.6",
         "@aws-sdk/xml-builder": "^3.972.16",
-        "@smithy/core": "^3.23.12",
+        "@smithy/core": "^3.23.13",
         "@smithy/node-config-provider": "^4.3.12",
         "@smithy/property-provider": "^4.2.12",
         "@smithy/protocol-http": "^5.3.12",
         "@smithy/signature-v4": "^5.3.12",
-        "@smithy/smithy-client": "^4.12.7",
+        "@smithy/smithy-client": "^4.12.8",
         "@smithy/types": "^4.13.1",
         "@smithy/util-base64": "^4.3.2",
         "@smithy/util-middleware": "^4.2.12",
@@ -782,23 +783,23 @@
       }
     },
     "node_modules/@aws-sdk/middleware-sdk-s3": {
-      "version": "3.972.26",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-sdk-s3/-/middleware-sdk-s3-3.972.26.tgz",
-      "integrity": "sha512-5q7UGSTtt7/KF0Os8wj2VZtlLxeWJVb0e2eDrDJlWot2EIxUNKDDMPFq/FowUqrwZ40rO2bu6BypxaKNvQhI+g==",
+      "version": "3.972.27",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-sdk-s3/-/middleware-sdk-s3-3.972.27.tgz",
+      "integrity": "sha512-gomO6DZwx+1D/9mbCpcqO5tPBqYBK7DtdgjTIjZ4yvfh/S7ETwAPS0XbJgP2JD8Ycr5CwVrEkV1sFtu3ShXeOw==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.973.25",
+        "@aws-sdk/core": "^3.973.26",
         "@aws-sdk/types": "^3.973.6",
         "@aws-sdk/util-arn-parser": "^3.972.3",
-        "@smithy/core": "^3.23.12",
+        "@smithy/core": "^3.23.13",
         "@smithy/node-config-provider": "^4.3.12",
         "@smithy/protocol-http": "^5.3.12",
         "@smithy/signature-v4": "^5.3.12",
-        "@smithy/smithy-client": "^4.12.7",
+        "@smithy/smithy-client": "^4.12.8",
         "@smithy/types": "^4.13.1",
         "@smithy/util-config-provider": "^4.2.2",
         "@smithy/util-middleware": "^4.2.12",
-        "@smithy/util-stream": "^4.5.20",
+        "@smithy/util-stream": "^4.5.21",
         "@smithy/util-utf8": "^4.2.2",
         "tslib": "^2.6.2"
       },
@@ -904,13 +905,32 @@
         "node": ">=20.0.0"
       }
     },
-    "node_modules/@aws-sdk/signature-v4-multi-region": {
-      "version": "3.996.14",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/signature-v4-multi-region/-/signature-v4-multi-region-3.996.14.tgz",
-      "integrity": "sha512-4nZSrBr1NO+48HCM/6BRU8mnRjuHZjcpziCvLXZk5QVftwWz5Mxqbhwdz4xf7WW88buaTB8uRO2MHklSX1m0vg==",
+    "node_modules/@aws-sdk/s3-request-presigner": {
+      "version": "3.1022.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/s3-request-presigner/-/s3-request-presigner-3.1022.0.tgz",
+      "integrity": "sha512-2arKiJswYGEOScAhEeOuy/1A1wScfgbfmU/6NAn0UK0/LDxqsOTc4/bCEuUK+/LtB+Lxu3rODqbY8V5gTGPLaQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/middleware-sdk-s3": "^3.972.26",
+        "@aws-sdk/signature-v4-multi-region": "^3.996.15",
+        "@aws-sdk/types": "^3.973.6",
+        "@aws-sdk/util-format-url": "^3.972.8",
+        "@smithy/middleware-endpoint": "^4.4.28",
+        "@smithy/protocol-http": "^5.3.12",
+        "@smithy/smithy-client": "^4.12.8",
+        "@smithy/types": "^4.13.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/signature-v4-multi-region": {
+      "version": "3.996.15",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/signature-v4-multi-region/-/signature-v4-multi-region-3.996.15.tgz",
+      "integrity": "sha512-Ukw2RpqvaL96CjfH/FgfBmy/ZosHBqoHBCFsN61qGg99F33vpntIVii8aNeh65XuOja73arSduskoa4OJea9RQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/middleware-sdk-s3": "^3.972.27",
         "@aws-sdk/types": "^3.973.6",
         "@smithy/protocol-http": "^5.3.12",
         "@smithy/signature-v4": "^5.3.12",
@@ -974,6 +994,21 @@
         "@smithy/types": "^4.13.1",
         "@smithy/url-parser": "^4.2.12",
         "@smithy/util-endpoints": "^3.3.3",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/util-format-url": {
+      "version": "3.972.8",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-format-url/-/util-format-url-3.972.8.tgz",
+      "integrity": "sha512-J6DS9oocrgxM8xlUTTmQOuwRF6rnAGEujAN9SAzllcrQmwn5iJ58ogxy3SEhD0Q7JZvlA5jvIXBkpQRqEqlE9A==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "^3.973.6",
+        "@smithy/querystring-builder": "^4.2.12",
+        "@smithy/types": "^4.13.1",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -3545,9 +3580,9 @@
       }
     },
     "node_modules/@smithy/core": {
-      "version": "3.23.12",
-      "resolved": "https://registry.npmjs.org/@smithy/core/-/core-3.23.12.tgz",
-      "integrity": "sha512-o9VycsYNtgC+Dy3I0yrwCqv9CWicDnke0L7EVOrZtJpjb2t0EjaEofmMrYc0T1Kn3yk32zm6cspxF9u9Bj7e5w==",
+      "version": "3.23.13",
+      "resolved": "https://registry.npmjs.org/@smithy/core/-/core-3.23.13.tgz",
+      "integrity": "sha512-J+2TT9D6oGsUVXVEMvz8h2EmdVnkBiy2auCie4aSJMvKlzUtO5hqjEzXhoCUkIMo7gAYjbQcN0g/MMSXEhDs1Q==",
       "license": "Apache-2.0",
       "dependencies": {
         "@smithy/protocol-http": "^5.3.12",
@@ -3556,7 +3591,7 @@
         "@smithy/util-base64": "^4.3.2",
         "@smithy/util-body-length-browser": "^4.2.2",
         "@smithy/util-middleware": "^4.2.12",
-        "@smithy/util-stream": "^4.5.20",
+        "@smithy/util-stream": "^4.5.21",
         "@smithy/util-utf8": "^4.2.2",
         "@smithy/uuid": "^1.1.2",
         "tslib": "^2.6.2"
@@ -3765,13 +3800,13 @@
       }
     },
     "node_modules/@smithy/middleware-endpoint": {
-      "version": "4.4.27",
-      "resolved": "https://registry.npmjs.org/@smithy/middleware-endpoint/-/middleware-endpoint-4.4.27.tgz",
-      "integrity": "sha512-T3TFfUgXQlpcg+UdzcAISdZpj4Z+XECZ/cefgA6wLBd6V4lRi0svN2hBouN/be9dXQ31X4sLWz3fAQDf+nt6BA==",
+      "version": "4.4.28",
+      "resolved": "https://registry.npmjs.org/@smithy/middleware-endpoint/-/middleware-endpoint-4.4.28.tgz",
+      "integrity": "sha512-p1gfYpi91CHcs5cBq982UlGlDrxoYUX6XdHSo91cQ2KFuz6QloHosO7Jc60pJiVmkWrKOV8kFYlGFFbQ2WUKKQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/core": "^3.23.12",
-        "@smithy/middleware-serde": "^4.2.15",
+        "@smithy/core": "^3.23.13",
+        "@smithy/middleware-serde": "^4.2.16",
         "@smithy/node-config-provider": "^4.3.12",
         "@smithy/shared-ini-file-loader": "^4.4.7",
         "@smithy/types": "^4.13.1",
@@ -3804,12 +3839,12 @@
       }
     },
     "node_modules/@smithy/middleware-serde": {
-      "version": "4.2.15",
-      "resolved": "https://registry.npmjs.org/@smithy/middleware-serde/-/middleware-serde-4.2.15.tgz",
-      "integrity": "sha512-ExYhcltZSli0pgAKOpQQe1DLFBLryeZ22605y/YS+mQpdNWekum9Ujb/jMKfJKgjtz1AZldtwA/wCYuKJgjjlg==",
+      "version": "4.2.16",
+      "resolved": "https://registry.npmjs.org/@smithy/middleware-serde/-/middleware-serde-4.2.16.tgz",
+      "integrity": "sha512-beqfV+RZ9RSv+sQqor3xroUUYgRFCGRw6niGstPG8zO9LgTl0B0MCucxjmrH/2WwksQN7UUgI7KNANoZv+KALA==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/core": "^3.23.12",
+        "@smithy/core": "^3.23.13",
         "@smithy/protocol-http": "^5.3.12",
         "@smithy/types": "^4.13.1",
         "tslib": "^2.6.2"
@@ -3847,12 +3882,11 @@
       }
     },
     "node_modules/@smithy/node-http-handler": {
-      "version": "4.5.0",
-      "resolved": "https://registry.npmjs.org/@smithy/node-http-handler/-/node-http-handler-4.5.0.tgz",
-      "integrity": "sha512-Rnq9vQWiR1+/I6NZZMNzJHV6pZYyEHt2ZnuV3MG8z2NNenC4i/8Kzttz7CjZiHSmsN5frhXhg17z3Zqjjhmz1A==",
+      "version": "4.5.1",
+      "resolved": "https://registry.npmjs.org/@smithy/node-http-handler/-/node-http-handler-4.5.1.tgz",
+      "integrity": "sha512-ejjxdAXjkPIs9lyYyVutOGNOraqUE9v/NjGMKwwFrfOM354wfSD8lmlj8hVwUzQmlLLF4+udhfCX9Exnbmvfzw==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/abort-controller": "^4.2.12",
         "@smithy/protocol-http": "^5.3.12",
         "@smithy/querystring-builder": "^4.2.12",
         "@smithy/types": "^4.13.1",
@@ -3960,17 +3994,17 @@
       }
     },
     "node_modules/@smithy/smithy-client": {
-      "version": "4.12.7",
-      "resolved": "https://registry.npmjs.org/@smithy/smithy-client/-/smithy-client-4.12.7.tgz",
-      "integrity": "sha512-q3gqnwml60G44FECaEEsdQMplYhDMZYCtYhMCzadCnRnnHIobZJjegmdoUo6ieLQlPUzvrMdIJUpx6DoPmzANQ==",
+      "version": "4.12.8",
+      "resolved": "https://registry.npmjs.org/@smithy/smithy-client/-/smithy-client-4.12.8.tgz",
+      "integrity": "sha512-aJaAX7vHe5i66smoSSID7t4rKY08PbD8EBU7DOloixvhOozfYWdcSYE4l6/tjkZ0vBZhGjheWzB2mh31sLgCMA==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/core": "^3.23.12",
-        "@smithy/middleware-endpoint": "^4.4.27",
+        "@smithy/core": "^3.23.13",
+        "@smithy/middleware-endpoint": "^4.4.28",
         "@smithy/middleware-stack": "^4.2.12",
         "@smithy/protocol-http": "^5.3.12",
         "@smithy/types": "^4.13.1",
-        "@smithy/util-stream": "^4.5.20",
+        "@smithy/util-stream": "^4.5.21",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -4153,13 +4187,13 @@
       }
     },
     "node_modules/@smithy/util-stream": {
-      "version": "4.5.20",
-      "resolved": "https://registry.npmjs.org/@smithy/util-stream/-/util-stream-4.5.20.tgz",
-      "integrity": "sha512-4yXLm5n/B5SRBR2p8cZ90Sbv4zL4NKsgxdzCzp/83cXw2KxLEumt5p+GAVyRNZgQOSrzXn9ARpO0lUe8XSlSDw==",
+      "version": "4.5.21",
+      "resolved": "https://registry.npmjs.org/@smithy/util-stream/-/util-stream-4.5.21.tgz",
+      "integrity": "sha512-KzSg+7KKywLnkoKejRtIBXDmwBfjGvg1U1i/etkC7XSWUyFCoLno1IohV2c74IzQqdhX5y3uE44r/8/wuK+A7Q==",
       "license": "Apache-2.0",
       "dependencies": {
         "@smithy/fetch-http-handler": "^5.3.15",
-        "@smithy/node-http-handler": "^4.5.0",
+        "@smithy/node-http-handler": "^4.5.1",
         "@smithy/types": "^4.13.1",
         "@smithy/util-base64": "^4.3.2",
         "@smithy/util-buffer-from": "^4.2.2",

--- a/apps/backend/package.json
+++ b/apps/backend/package.json
@@ -24,6 +24,7 @@
   },
   "dependencies": {
     "@aws-sdk/client-s3": "^3.1018.0",
+    "@aws-sdk/s3-request-presigner": "^3.1022.0",
     "@nestjs/common": "^11.0.1",
     "@nestjs/config": "^4.0.3",
     "@nestjs/core": "^11.0.1",

--- a/apps/backend/src/receipts/receipts.controller.ts
+++ b/apps/backend/src/receipts/receipts.controller.ts
@@ -157,6 +157,15 @@ export class ReceiptsController {
     await this.receiptsService.deleteReceipt(id, user.id);
   }
 
+  @Get(':id/image-url')
+  async getReceiptImagePresignedUrl(
+    @CurrentUser() user: User,
+    @Param('id', ParseUUIDPipe) id: string,
+  ): Promise<{ url: string }> {
+    const url = await this.receiptsService.getReceiptImagePresignedUrl(id, user.id);
+    return { url };
+  }
+
   @Get(':id/image')
   @Header('Cache-Control', 'private, max-age=3600')
   async getReceiptImage(

--- a/apps/backend/src/receipts/receipts.service.ts
+++ b/apps/backend/src/receipts/receipts.service.ts
@@ -278,6 +278,14 @@ export class ReceiptsService {
     return { buffer, mimeType };
   }
 
+  async getReceiptImagePresignedUrl(receiptId: string, userId: string): Promise<string> {
+    const receipt = await this.receiptsRepository.findOneBy({ id: receiptId, userId });
+    if (!receipt) {
+      throw new NotFoundException(`レシートが見つかりません: ${receiptId}`);
+    }
+    return this.s3Service.getPresignedUrl(receipt.s3Key);
+  }
+
   async listReceipts(userId: string): Promise<Receipt[]> {
     return this.receiptsRepository.find({
       where: { userId },

--- a/apps/backend/src/s3/s3.service.ts
+++ b/apps/backend/src/s3/s3.service.ts
@@ -5,6 +5,7 @@ import {
   PutObjectCommand,
   S3Client,
 } from '@aws-sdk/client-s3';
+import { getSignedUrl } from '@aws-sdk/s3-request-presigner';
 
 interface S3UploadParams {
   buffer: Buffer;
@@ -48,6 +49,19 @@ export class S3Service {
         `S3へのアップロードに失敗しました: ${String(error)}`,
       );
     }
+  }
+
+  async getPresignedUrl(s3Key: string, expiresIn = 3600): Promise<string> {
+    const command = new GetObjectCommand({ Bucket: this.bucket, Key: s3Key });
+    const url = await getSignedUrl(this.client, command, { expiresIn });
+
+    // Docker環境ではPresigned URLが内部ホスト名になるため、ブラウザアクセス可能なURLに書き換える
+    const internalEndpoint = this.configService.get<string>('S3_ENDPOINT');
+    const publicEndpoint = this.configService.get<string>('S3_PUBLIC_ENDPOINT');
+    if (internalEndpoint && publicEndpoint) {
+      return url.replace(internalEndpoint, publicEndpoint);
+    }
+    return url;
   }
 
   async getObject(s3Key: string): Promise<Buffer> {

--- a/apps/frontend/src/app/receipts/[id]/duplicates/_components/DuplicateConfirmContent.tsx
+++ b/apps/frontend/src/app/receipts/[id]/duplicates/_components/DuplicateConfirmContent.tsx
@@ -10,6 +10,8 @@ interface DuplicateConfirmContentProps {
   receipt: GetReceiptDetailResponse;
   duplicate: GetReceiptDetailResponse;
   token: string;
+  imageUrl?: string;
+  duplicateImageUrl?: string;
   duplicateIndex: number;
   duplicateTotal: number;
 }
@@ -18,6 +20,8 @@ export function DuplicateConfirmContent({
   receipt,
   duplicate,
   token,
+  imageUrl,
+  duplicateImageUrl,
   duplicateIndex,
   duplicateTotal,
 }: DuplicateConfirmContentProps) {
@@ -53,7 +57,7 @@ export function DuplicateConfirmContent({
               新しいレシート
             </span>
           </div>
-          <ReceiptDetailContent receipt={receipt} token={token} />
+          <ReceiptDetailContent receipt={receipt} imageUrl={imageUrl} />
         </div>
 
         {/* 既存レシート（右） */}
@@ -68,7 +72,7 @@ export function DuplicateConfirmContent({
               </span>
             )}
           </div>
-          <ReceiptDetailContent receipt={duplicate} token={token} />
+          <ReceiptDetailContent receipt={duplicate} imageUrl={duplicateImageUrl} />
         </div>
       </div>
 

--- a/apps/frontend/src/app/receipts/[id]/duplicates/page.tsx
+++ b/apps/frontend/src/app/receipts/[id]/duplicates/page.tsx
@@ -2,7 +2,7 @@ import { auth } from '../../../../../auth';
 import { redirect, notFound } from 'next/navigation';
 import Link from 'next/link';
 import { AppHeader } from '../../../../components/AppHeader';
-import { getReceiptDetail } from '../../../../lib/api/receipts';
+import { getReceiptDetail, getReceiptImagePresignedUrl } from '../../../../lib/api/receipts';
 import { DuplicateConfirmContent } from './_components/DuplicateConfirmContent';
 
 interface DuplicateCheckPageProps {
@@ -33,9 +33,11 @@ export default async function DuplicateCheckPage({
     receipt.possibleDuplicateIds.length - 1,
   );
   const duplicateId = receipt.possibleDuplicateIds[duplicateIndex];
-  const duplicate = await getReceiptDetail(duplicateId, session.backendToken).catch(() =>
-    notFound(),
-  );
+  const [duplicate, imageUrl, duplicateImageUrl] = await Promise.all([
+    getReceiptDetail(duplicateId, session.backendToken).catch(() => notFound()),
+    getReceiptImagePresignedUrl(id, session.backendToken).catch(() => null),
+    getReceiptImagePresignedUrl(duplicateId, session.backendToken).catch(() => null),
+  ]);
 
   return (
     <div className="min-h-screen bg-zinc-50 dark:bg-black">
@@ -81,6 +83,8 @@ export default async function DuplicateCheckPage({
           receipt={receipt}
           duplicate={duplicate}
           token={session.backendToken}
+          imageUrl={imageUrl ?? undefined}
+          duplicateImageUrl={duplicateImageUrl ?? undefined}
           duplicateIndex={duplicateIndex}
           duplicateTotal={receipt.possibleDuplicateIds.length}
         />

--- a/apps/frontend/src/app/receipts/[id]/page.tsx
+++ b/apps/frontend/src/app/receipts/[id]/page.tsx
@@ -3,7 +3,7 @@ import { redirect, notFound } from 'next/navigation';
 import Link from 'next/link';
 import { AppHeader } from '../../../components/AppHeader';
 import { ReceiptDetailContent } from '../../../components/ReceiptDetailContent';
-import { getReceiptDetail } from '../../../lib/api/receipts';
+import { getReceiptDetail, getReceiptImagePresignedUrl } from '../../../lib/api/receipts';
 
 interface ReceiptDetailPageProps {
   params: Promise<{ id: string }>;
@@ -17,7 +17,10 @@ export default async function ReceiptDetailPage({ params }: ReceiptDetailPagePro
   }
 
   const { id } = await params;
-  const receipt = await getReceiptDetail(id, session.backendToken).catch(() => notFound());
+  const [receipt, imageUrl] = await Promise.all([
+    getReceiptDetail(id, session.backendToken).catch(() => notFound()),
+    getReceiptImagePresignedUrl(id, session.backendToken).catch(() => null),
+  ]);
 
   return (
     <div className="min-h-screen bg-zinc-50 dark:bg-black">
@@ -31,7 +34,7 @@ export default async function ReceiptDetailPage({ params }: ReceiptDetailPagePro
           ← レシート一覧
         </Link>
 
-        <ReceiptDetailContent receipt={receipt} token={session.backendToken} />
+        <ReceiptDetailContent receipt={receipt} imageUrl={imageUrl ?? undefined} />
       </main>
     </div>
   );

--- a/apps/frontend/src/components/ReceiptDetailContent.tsx
+++ b/apps/frontend/src/components/ReceiptDetailContent.tsx
@@ -1,14 +1,13 @@
 'use client';
 
-import { useState, useEffect } from 'react';
+import { useState } from 'react';
 import Image from 'next/image';
 import { GetReceiptDetailResponse, ReceiptItemDetail, UpdateReceiptItemRequest } from '../types/receipt';
-import { getReceiptImageUrl } from '../lib/api/receipts';
 
 interface ViewProps {
   receipt: GetReceiptDetailResponse;
   editMode?: false;
-  token?: string;
+  imageUrl?: string;
 }
 
 interface EditProps {
@@ -103,44 +102,12 @@ const inputClass =
 export function ReceiptDetailContent(props: ReceiptDetailContentProps) {
   const { receipt } = props;
   const isEdit = props.editMode === true;
-  const token = !isEdit ? (props as ViewProps).token : undefined;
+  const imageUrl = !isEdit ? (props as ViewProps).imageUrl : undefined;
 
   const [storeName, setStoreName] = useState(receipt.storeName ?? '');
   const [purchasedAt, setPurchasedAt] = useState(toDateInputValue(receipt.purchasedAt));
   const [items, setItems] = useState<ItemState[]>(receipt.items.map(toItemState));
-
-  // receipt.id と token の組み合わせをキーに、取得結果をまとめて管理する
-  // ローディング状態はキーの一致/不一致から派生させることで effect 内の setState を不要にする
-  const [imageFetch, setImageFetch] = useState<{
-    key: string | null;
-    url: string | null;
-    error: boolean;
-  }>({ key: null, url: null, error: false });
   const [isImageModalOpen, setIsImageModalOpen] = useState(false);
-
-  const imageFetchKey = token ? `${receipt.id}:${token}` : null;
-  const imageUrl = imageFetch.key === imageFetchKey ? imageFetch.url : null;
-  const imageStatus: 'idle' | 'loading' | 'error' =
-    imageFetch.error && imageFetch.key === imageFetchKey
-      ? 'error'
-      : imageFetchKey !== null && imageFetch.key !== imageFetchKey
-        ? 'loading'
-        : 'idle';
-
-  useEffect(() => {
-    if (!token) return;
-    const fetchKey = `${receipt.id}:${token}`;
-    let objectUrl: string | null = null;
-    getReceiptImageUrl(receipt.id, token)
-      .then((url) => {
-        objectUrl = url;
-        setImageFetch({ key: fetchKey, url, error: false });
-      })
-      .catch(() => setImageFetch({ key: fetchKey, url: null, error: true }));
-    return () => {
-      if (objectUrl) URL.revokeObjectURL(objectUrl);
-    };
-  }, [receipt.id, token]);
 
   const updateItem = (
     localId: string,
@@ -218,34 +185,22 @@ export function ReceiptDetailContent(props: ReceiptDetailContentProps) {
       )}
 
       {/* レシート画像 */}
-      {token && (
+      {imageUrl && (
         <div className="overflow-hidden rounded-2xl bg-white shadow-sm dark:bg-zinc-900">
-          {imageStatus === 'loading' && (
-            <div className="flex items-center justify-center p-8">
-              <p className="text-sm text-zinc-400 dark:text-zinc-600">画像を読み込み中…</p>
-            </div>
-          )}
-          {imageStatus === 'error' && (
-            <div className="flex items-center justify-center p-8">
-              <p className="text-sm text-red-400">画像の取得に失敗しました</p>
-            </div>
-          )}
-          {imageUrl && (
-            <button
-              onClick={() => setIsImageModalOpen(true)}
-              className="block w-full"
-              aria-label="レシート画像を拡大表示"
-            >
-              <Image
-                src={imageUrl}
-                alt="レシート画像"
-                width={800}
-                height={1200}
-                unoptimized
-                className="max-h-64 w-full object-contain"
-              />
-            </button>
-          )}
+          <button
+            onClick={() => setIsImageModalOpen(true)}
+            className="block w-full"
+            aria-label="レシート画像を拡大表示"
+          >
+            <Image
+              src={imageUrl}
+              alt="レシート画像"
+              width={800}
+              height={1200}
+              unoptimized
+              className="max-h-64 w-full object-contain"
+            />
+          </button>
         </div>
       )}
 

--- a/apps/frontend/src/lib/api/receipts.ts
+++ b/apps/frontend/src/lib/api/receipts.ts
@@ -127,17 +127,17 @@ export async function deleteReceipt(id: string, token: string): Promise<void> {
   }
 }
 
-export async function getReceiptImageUrl(id: string, token: string): Promise<string> {
-  const res = await fetch(`${backendUrl}/receipts/${id}/image`, {
+export async function getReceiptImagePresignedUrl(id: string, token: string): Promise<string> {
+  const res = await fetch(`${backendUrl}/receipts/${id}/image-url`, {
     headers: { Authorization: `Bearer ${token}` },
   });
 
   if (!res.ok) {
-    throw new Error(`画像の取得に失敗しました (${res.status})`);
+    throw new Error(`画像URLの取得に失敗しました (${res.status})`);
   }
 
-  const blob = await res.blob();
-  return URL.createObjectURL(blob);
+  const data = (await res.json()) as { url: string };
+  return data.url;
 }
 
 export async function uploadReceipt(

--- a/docs/issue-task/impl-plan-99-presigned-url.md
+++ b/docs/issue-task/impl-plan-99-presigned-url.md
@@ -1,0 +1,220 @@
+# Issue #99 修正実装計画：S3 Presigned URL移行
+
+## Context
+
+レシート詳細ページの画像読み込みが遅い問題（issue #99）を修正する。
+
+**現在の画像取得経路**：
+```
+ブラウザ → ALB → NestJS → S3 → NestJS → ALB → ブラウザ  (プロキシ経由)
+↑ さらに useEffect によるCSR追加往復も発生
+```
+
+**目指す経路**：
+```
+SSR時: NestJS → S3（presigned URL生成のみ）
+      ↓ URLをHTMLに埋め込む
+ブラウザ → S3 直接アクセス（NestJSプロキシ不要）
+```
+
+S3 Presigned URL 方式により、NestJSプロキシの排除・CSR往復の解消・Buffer全量メモリ収集の解消をまとめて達成する。
+
+---
+
+## 対象ファイル
+
+| 変更種別 | ファイル |
+|--------|---------|
+| 追加 | `apps/backend/src/s3/s3.service.ts` |
+| 追加 | `apps/backend/src/receipts/receipts.service.ts` |
+| 追加 | `apps/backend/src/receipts/receipts.controller.ts` |
+| 変更 | `apps/frontend/src/lib/api/receipts.ts` |
+| 変更 | `apps/frontend/src/app/receipts/[id]/page.tsx` |
+| 変更 | `apps/frontend/src/components/ReceiptDetailContent.tsx` |
+| 変更 | `apps/backend/package.json` |
+| 変更 | `.env`（ローカル開発用） |
+
+---
+
+## 実装手順
+
+### Step 1: `@aws-sdk/s3-request-presigner` インストール
+
+`apps/backend/package.json` に追加。`@aws-sdk/client-s3` と同じメジャーバージョン（現在 `^3.x`）を使用。
+
+```bash
+cd apps/backend && npm install @aws-sdk/s3-request-presigner
+```
+
+---
+
+### Step 2: `S3Service.getPresignedUrl` 追加
+
+**ファイル**: `apps/backend/src/s3/s3.service.ts`
+
+`getSignedUrl`（`@aws-sdk/s3-request-presigner`）を使用し、`GetObjectCommand` に署名付きURLを生成する。
+
+**ローカル開発の考慮点**：  
+LocalStack の Presigned URL は Docker 内部ホスト名（`http://localstack:4566/...`）になりブラウザから到達不可。`S3_PUBLIC_ENDPOINT` 環境変数（設定時のみ有効）でホスト部分を書き換える。これは `S3_ENDPOINT`（内部通信用）と分離することでアプリコードに環境分岐を持ち込まない原則5に準拠。
+
+```typescript
+async getPresignedUrl(s3Key: string, expiresIn = 3600): Promise<string> {
+  const command = new GetObjectCommand({ Bucket: this.bucket, Key: s3Key });
+  const url = await getSignedUrl(this.client, command, { expiresIn });
+
+  // Docker環境ではPresigned URLが内部ホスト名になるため、ブラウザアクセス可能なURLに書き換える
+  const internalEndpoint = this.configService.get<string>('S3_ENDPOINT');
+  const publicEndpoint = this.configService.get<string>('S3_PUBLIC_ENDPOINT');
+  if (internalEndpoint && publicEndpoint) {
+    return url.replace(internalEndpoint, publicEndpoint);
+  }
+  return url;
+}
+```
+
+---
+
+### Step 3: `ReceiptsService.getReceiptImagePresignedUrl` 追加
+
+**ファイル**: `apps/backend/src/receipts/receipts.service.ts`
+
+```typescript
+async getReceiptImagePresignedUrl(receiptId: string, userId: string): Promise<string> {
+  const receipt = await this.receiptsRepository.findOneBy({ id: receiptId, userId });
+  if (!receipt) throw new NotFoundException(`レシートが見つかりません: ${receiptId}`);
+  return this.s3Service.getPresignedUrl(receipt.s3Key);
+}
+```
+
+---
+
+### Step 4: `ReceiptsController` に `GET :id/image-url` 追加
+
+**ファイル**: `apps/backend/src/receipts/receipts.controller.ts`
+
+```typescript
+@Get(':id/image-url')
+async getReceiptImagePresignedUrl(
+  @CurrentUser() user: User,
+  @Param('id', ParseUUIDPipe) id: string,
+): Promise<{ url: string }> {
+  const url = await this.receiptsService.getReceiptImagePresignedUrl(id, user.id);
+  return { url };
+}
+```
+
+**注意**: `GET :id/image-url` は `GET :id` よりも前に定義する必要がある（NestJSのルート解決順序）。  
+既存の `GET :id/image`（バイナリプロキシ）は**残す**。
+
+---
+
+### Step 5: `receipts.ts` API ラッパー修正
+
+**ファイル**: `apps/frontend/src/lib/api/receipts.ts`
+
+- 旧 `getReceiptImageUrl`（blob取得、クライアントサイド）を**削除**
+- SSR用 `getReceiptImagePresignedUrl` を**追加**
+
+```typescript
+export async function getReceiptImagePresignedUrl(
+  id: string,
+  token: string,
+): Promise<string> {
+  const res = await fetch(`${backendUrl}/receipts/${id}/image-url`, {
+    headers: { Authorization: `Bearer ${token}` },
+  });
+
+  if (!res.ok) {
+    throw new Error(`画像URLの取得に失敗しました (${res.status})`);
+  }
+
+  const data = (await res.json()) as { url: string };
+  return data.url;
+}
+```
+
+---
+
+### Step 6: `ReceiptDetailPage` 修正（SSRでURL取得）
+
+**ファイル**: `apps/frontend/src/app/receipts/[id]/page.tsx`
+
+```typescript
+const [receipt, imageUrl] = await Promise.all([
+  getReceiptDetail(id, session.backendToken).catch(() => notFound()),
+  getReceiptImagePresignedUrl(id, session.backendToken).catch(() => null),
+]);
+
+// ...
+<ReceiptDetailContent receipt={receipt} imageUrl={imageUrl ?? undefined} />
+```
+
+`token` prop は渡さない（クライアントサイドでの画像フェッチが不要になるため）。
+
+---
+
+### Step 7: `ReceiptDetailContent` 修正
+
+**ファイル**: `apps/frontend/src/components/ReceiptDetailContent.tsx`
+
+**削除するもの**：
+- `ViewProps` の `token?: string`
+- `getReceiptImageUrl` import
+- `imageFetch` state と `imageFetchKey`、`imageStatus` の計算ロジック（L112-128）
+- `useEffect` による画像フェッチ（L130-143）
+
+**追加するもの**：
+- `ViewProps` に `imageUrl?: string` prop
+
+**変更後のイメージ**：
+```typescript
+interface ViewProps {
+  receipt: GetReceiptDetailResponse;
+  editMode?: false;
+  imageUrl?: string;  // token の代わりにSSR生成済みURLを受け取る
+}
+```
+
+レンダリング部分は `imageUrl` を直接使用：
+```tsx
+{imageUrl && (
+  <div className="overflow-hidden rounded-2xl bg-white shadow-sm dark:bg-zinc-900">
+    <button onClick={() => setIsImageModalOpen(true)} ...>
+      <Image src={imageUrl} alt="レシート画像" width={800} height={1200} unoptimized ... />
+    </button>
+  </div>
+)}
+```
+
+`loading` / `error` 状態はPresigned URL自体の取得失敗を `page.tsx` 側で `null` として処理するため、コンポーネント内のローディング表示は不要になる。
+
+---
+
+### Step 8: ローカル開発 `.env` に `S3_PUBLIC_ENDPOINT` 追加
+
+```
+S3_PUBLIC_ENDPOINT=http://localhost:4566
+```
+
+これは既存の `.env`（開発者のローカル）に追記する。LocalStack ポート `4566` はすでに `docker-compose.yml` で公開済み。
+
+---
+
+## スコープ外（別 Issue 推奨）
+
+| 項目 | 理由 |
+|-----|-----|
+| アップロード時の画像圧縮（sharp） | 独立した改善でこのIssueと分離可能 |
+| `next/image` の remotePatterns 設定 | S3ドメインが本番/ローカルで異なり設定が複雑。`unoptimized` のままで機能的には問題なし |
+| Nginxキャッシュ | 優先度低。Presigned URL方式ではNestJS経由でないためnginx通過せず |
+| 既存 `GET :id/image` エンドポイントの削除 | 廃止は別PRで行う |
+
+---
+
+## 検証方法
+
+1. **ローカル起動**: `docker compose up` で全サービスを起動
+2. **レシートアップロード**: ファイルをアップロードし解析完了を確認
+3. **詳細ページ表示**: 画像が表示されることを確認（DevToolsのネットワークタブで `localhost:4566` への直接リクエストが飛ぶことを確認）
+4. **SSR確認**: ページソースに `localhost:4566` のURLが含まれていることを確認
+5. **エラーケース**: 存在しないIDでアクセスした場合に `notFound()` になることを確認


### PR DESCRIPTION
## Summary

- バックエンド経由の画像プロキシを廃止し、S3 Presigned URL でブラウザから直接アクセスする方式に移行
- SSR でpresigned URLを生成して HTML に埋め込み、CSR 追加往復（`useEffect` フェッチ）を解消
- `S3_PUBLIC_ENDPOINT` 環境変数で LocalStack の内部ホスト名をブラウザアクセス可能な URL に書き換え（ローカル開発用）

**改善前の画像取得経路**
```
ブラウザ → ALB → NestJS → S3 → NestJS → ALB → ブラウザ（CSR往復あり）
```

**改善後の画像取得経路**
```
SSR時: NestJS → S3（presigned URL生成のみ）→ URLをHTMLに埋め込み
ブラウザ → S3 直接アクセス
```

## Changes

- `apps/backend/src/s3/s3.service.ts`: `getPresignedUrl()` メソッド追加
- `apps/backend/src/receipts/receipts.service.ts`: `getReceiptImagePresignedUrl()` メソッド追加
- `apps/backend/src/receipts/receipts.controller.ts`: `GET /receipts/:id/image-url` エンドポイント追加
- `apps/frontend/src/lib/api/receipts.ts`: `getReceiptImageUrl`（blob取得）→ `getReceiptImagePresignedUrl`（SSR用）に置換
- `apps/frontend/src/app/receipts/[id]/page.tsx`: SSR で presigned URL 取得・`imageUrl` prop で渡す
- `apps/frontend/src/components/ReceiptDetailContent.tsx`: `token`/`useEffect`/`imageFetch` state を削除
- `apps/frontend/src/app/receipts/[id]/duplicates/page.tsx`: 両レシートの presigned URL を SSR 取得
- `apps/frontend/src/app/receipts/[id]/duplicates/_components/DuplicateConfirmContent.tsx`: `imageUrl`/`duplicateImageUrl` prop 対応
- `.env`: `S3_PUBLIC_ENDPOINT=http://localhost:4566` 追加（ローカル開発用）
- `apps/backend/package.json`: `@aws-sdk/s3-request-presigner` 追加

## Test plan

- [ ] `docker compose up` でローカル環境を起動
- [ ] レシートをアップロードして解析完了まで待機
- [ ] レシート詳細ページを開き、画像が表示されることを確認
- [ ] DevTools ネットワークタブで `localhost:4566` への直接リクエストが発生することを確認（NestJS プロキシが不要になっていること）
- [ ] ページソースに `localhost:4566` の URL が含まれていることを確認（SSR 生成）
- [ ] 重複確認ページで両レシートの画像が表示されることを確認

Closes #99

🤖 Generated with [Claude Code](https://claude.com/claude-code)