### PR TITLE
add: フロントエンドbasePath /credit-checkerを設定 #152

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -11,7 +11,7 @@ S3_BUCKET_NAME=credit-checker-dev
 FRONTEND_URL=http://localhost:3000
 BACKEND_URL=http://backend:3003/api/v1
 NEXT_PUBLIC_BACKEND_URL=http://localhost:3003/api/v1
-AUTH_URL=http://localhost:3000
+AUTH_URL=http://localhost:3000/credit-checker
 AUTH_GOOGLE_ID=
 
 # Postgres（docker compose でのみ使用）

--- a/apps/frontend/next.config.ts
+++ b/apps/frontend/next.config.ts
@@ -1,6 +1,7 @@
 import type { NextConfig } from 'next';
 
 const nextConfig: NextConfig = {
+  basePath: '/credit-checker',
   output: 'standalone',
   experimental: {
     // CloudFront → ALB 経由だと Host ヘッダーが ALB の DNS 名に書き換わり

--- a/infra/lib/app/app-stack.ts
+++ b/infra/lib/app/app-stack.ts
@@ -137,7 +137,7 @@ export class AppStack extends cdk.Stack {
         AUTH_GOOGLE_ID: config.authGoogleId,
         BACKEND_URL: `https://${config.domain}/api/v1`,
         NEXT_PUBLIC_BACKEND_URL: `https://${config.domain}/api/v1`,
-        AUTH_URL: `https://${config.domain}`,
+        AUTH_URL: `https://${config.domain}/credit-checker`,
       },
       secrets: {
         AUTH_SECRET: ecs.Secret.fromSecretsManager(authSecret),

--- a/infra/lib/edge/edge-stack.ts
+++ b/infra/lib/edge/edge-stack.ts
@@ -85,7 +85,7 @@ export class EdgeStack extends cdk.Stack {
       protocol: elbv2.ApplicationProtocol.HTTP,
       targets: [frontendService],
       healthCheck: {
-        path: '/',
+        path: '/credit-checker',
         interval: cdk.Duration.seconds(30),
       },
     });


### PR DESCRIPTION
## Summary

- `next.config.ts` に `basePath: '/credit-checker'` を追加（dev・prod 両環境に適用）
- ALB ヘルスチェックパスを `'/'` から `'/credit-checker'` に変更（basePath 設定後は `/` が 404 を返すため）
- ECS 環境変数 `AUTH_URL` に `/credit-checker` を付加（Auth.js v5 がコールバック URL 生成に使用）
- `.env.example` の `AUTH_URL` を `http://localhost:3000/credit-checker` に更新

Closes #152

## Test plan

- [ ] ローカル: `docker compose up` → `http://localhost:3000/credit-checker` でアクセス確認
- [ ] Auth.js Google ログイン: コールバックが `/credit-checker/api/auth/callback/google` に届くこと
- [ ] CDK デプロイ後: `https://dev.jun-eg.site/credit-checker` でアクセス確認
- [ ] ALB ヘルスチェック: ECS タスクが healthy になること
- [ ] **Google Cloud Console で OAuth コールバック URL を追加**（デプロイ前に実施）
  - 追加: `https://dev.jun-eg.site/credit-checker/api/auth/callback/google`

🤖 Generated with [Claude Code](https://claude.com/claude-code)