### PR TITLE
fix: ECSデプロイのwait services-stableタイムアウトを修正 #156

### DIFF
--- a/.github/workflows/reusable-app-deploy.yml
+++ b/.github/workflows/reusable-app-deploy.yml
@@ -174,10 +174,32 @@ jobs:
             --task-definition "${{ steps.register_tasks.outputs.BACKEND_ARN }}"
 
       - name: Wait for stable
+        timeout-minutes: 20
         run: |
-          aws ecs wait services-stable \
-            --cluster ${{ vars.APP_NAME }}-${{ inputs.environment }} \
-            --services ${{ vars.APP_NAME }}-frontend-${{ inputs.environment }} ${{ vars.APP_NAME }}-backend-${{ inputs.environment }}
+          APP="${{ vars.APP_NAME }}"
+          ENV="${{ inputs.environment }}"
+          CLUSTER="${APP}-${ENV}"
+          SERVICES="${APP}-frontend-${ENV} ${APP}-backend-${ENV}"
+
+          # aws ecs wait は最大10分(40回×15秒)のため、ポーリングループで延長
+          DEADLINE=$((SECONDS + 1200))
+          until [ $SECONDS -ge $DEADLINE ]; do
+            STATUSES=$(aws ecs describe-services \
+              --cluster "$CLUSTER" \
+              --services $SERVICES \
+              --query 'services[*].deployments[?status==`PRIMARY`].rolloutState' \
+              --output text)
+
+            if echo "$STATUSES" | grep -qv "COMPLETED"; then
+              echo "Waiting... statuses: $STATUSES"
+              sleep 15
+            else
+              echo "All services stable."
+              exit 0
+            fi
+          done
+          echo "Timed out waiting for services to stabilize."
+          exit 1
 
       - name: Rollback on failure
         if: failure() && steps.ecs_update.outcome == 'success'


### PR DESCRIPTION
## Summary
- `aws ecs wait services-stable` のデフォルトタイムアウト（10分）超過によるCIエラーを修正
- `wait` コマンドをポーリングループに置き換え、最大20分待機するよう変更
- ステップに `timeout-minutes: 20` を設定し、GitHub Actions側でも上限を保証

## Test plan
- [ ] `develop` へのデプロイワークフローが正常に完了することを確認
- [ ] サービスが20分以内に安定した場合に `exit 0` で終了することを確認

Closes #156

🤖 Generated with [Claude Code](https://claude.com/claude-code)