### PR TITLE
add: Room機能実装（DB・Backend・Frontend） #92~#98

### DIFF
--- a/apps/backend/src/app.module.ts
+++ b/apps/backend/src/app.module.ts
@@ -14,6 +14,7 @@ import { RoomMember } from './entities/room-member.entity';
 import { User } from './entities/user.entity';
 import { UsersModule } from './users/users.module';
 import { ChatModule } from './chat/chat.module';
+import { RoomsModule } from './rooms/rooms.module';
 import { secrets } from './config/secrets';
 
 @Module({
@@ -46,6 +47,7 @@ import { secrets } from './config/secrets';
     UsersModule,
     ReceiptsModule,
     ChatModule,
+    RoomsModule,
   ],
   controllers: [AppController],
   providers: [AppService],

--- a/apps/backend/src/app.module.ts
+++ b/apps/backend/src/app.module.ts
@@ -9,6 +9,8 @@ import { ChatMessage } from './entities/chat-message.entity';
 import { ChatSession } from './entities/chat-session.entity';
 import { Receipt } from './entities/receipt.entity';
 import { ReceiptItem } from './entities/receipt-item.entity';
+import { Room } from './entities/room.entity';
+import { RoomMember } from './entities/room-member.entity';
 import { User } from './entities/user.entity';
 import { UsersModule } from './users/users.module';
 import { ChatModule } from './chat/chat.module';
@@ -31,7 +33,7 @@ import { secrets } from './config/secrets';
       useFactory: (config: ConfigService) => ({
         type: 'postgres',
         url: secrets.databaseUrl(),
-        entities: [User, Receipt, ReceiptItem, ChatSession, ChatMessage],
+        entities: [User, Receipt, ReceiptItem, ChatSession, ChatMessage, Room, RoomMember],
         migrations: ['dist/migrations/*.js'],
         synchronize: false,
         logging: process.env.TYPEORM_LOGGING === 'true',

--- a/apps/backend/src/entities/receipt.entity.ts
+++ b/apps/backend/src/entities/receipt.entity.ts
@@ -10,6 +10,7 @@ import {
 } from 'typeorm';
 import { User } from './user.entity';
 import { ReceiptItem } from './receipt-item.entity';
+import { Room } from './room.entity';
 
 export enum ReceiptStatus {
   PENDING = 'pending',
@@ -57,6 +58,9 @@ export class Receipt {
   @Column({ name: 'possible_duplicate_ids', type: 'jsonb', nullable: true })
   possibleDuplicateIds: string[] | null;
 
+  @Column({ name: 'room_id', nullable: true })
+  roomId: string | null;
+
   @CreateDateColumn({ name: 'created_at' })
   createdAt: Date;
 
@@ -71,4 +75,8 @@ export class Receipt {
     cascade: true,
   })
   items: ReceiptItem[];
+
+  @ManyToOne(() => Room, { nullable: true, onDelete: 'SET NULL' })
+  @JoinColumn({ name: 'room_id' })
+  room: Room | null;
 }

--- a/apps/backend/src/entities/room-member.entity.ts
+++ b/apps/backend/src/entities/room-member.entity.ts
@@ -31,7 +31,7 @@ export class RoomMember {
   @CreateDateColumn({ name: 'joined_at' })
   joinedAt: Date;
 
-  @ManyToOne(() => Room, (room) => room.members, { onDelete: 'CASCADE' })
+  @ManyToOne(() => Room, (room: Room) => room.members, { onDelete: 'CASCADE' })
   @JoinColumn({ name: 'room_id' })
   room: Room;
 

--- a/apps/backend/src/entities/room-member.entity.ts
+++ b/apps/backend/src/entities/room-member.entity.ts
@@ -1,0 +1,41 @@
+import {
+  Column,
+  CreateDateColumn,
+  Entity,
+  JoinColumn,
+  ManyToOne,
+  PrimaryGeneratedColumn,
+} from 'typeorm';
+import { Room } from './room.entity';
+import { User } from './user.entity';
+
+export enum RoomMemberRole {
+  OWNER = 'owner',
+  MEMBER = 'member',
+}
+
+@Entity('room_members')
+export class RoomMember {
+  @PrimaryGeneratedColumn('uuid')
+  id: string;
+
+  @Column({ name: 'room_id' })
+  roomId: string;
+
+  @Column({ name: 'user_id' })
+  userId: string;
+
+  @Column({ type: 'enum', enum: RoomMemberRole })
+  role: RoomMemberRole;
+
+  @CreateDateColumn({ name: 'joined_at' })
+  joinedAt: Date;
+
+  @ManyToOne(() => Room, (room) => room.members, { onDelete: 'CASCADE' })
+  @JoinColumn({ name: 'room_id' })
+  room: Room;
+
+  @ManyToOne(() => User, { onDelete: 'CASCADE' })
+  @JoinColumn({ name: 'user_id' })
+  user: User;
+}

--- a/apps/backend/src/entities/room.entity.ts
+++ b/apps/backend/src/entities/room.entity.ts
@@ -29,7 +29,7 @@ export class Room {
   @JoinColumn({ name: 'owner_id' })
   owner: User;
 
-  @OneToMany(() => RoomMember, (member) => member.room)
+  @OneToMany(() => RoomMember, (member: RoomMember) => member.room)
   members: RoomMember[];
 
   @CreateDateColumn({ name: 'created_at' })

--- a/apps/backend/src/entities/room.entity.ts
+++ b/apps/backend/src/entities/room.entity.ts
@@ -1,0 +1,40 @@
+import {
+  Column,
+  CreateDateColumn,
+  Entity,
+  JoinColumn,
+  ManyToOne,
+  OneToMany,
+  PrimaryGeneratedColumn,
+  UpdateDateColumn,
+} from 'typeorm';
+import { User } from './user.entity';
+import { RoomMember } from './room-member.entity';
+
+@Entity('rooms')
+export class Room {
+  @PrimaryGeneratedColumn('uuid')
+  id: string;
+
+  @Column({ type: 'varchar' })
+  name: string;
+
+  @Column({ name: 'owner_id' })
+  ownerId: string;
+
+  @Column({ name: 'invite_code', type: 'varchar', unique: true })
+  inviteCode: string;
+
+  @ManyToOne(() => User, { onDelete: 'CASCADE' })
+  @JoinColumn({ name: 'owner_id' })
+  owner: User;
+
+  @OneToMany(() => RoomMember, (member) => member.room)
+  members: RoomMember[];
+
+  @CreateDateColumn({ name: 'created_at' })
+  createdAt: Date;
+
+  @UpdateDateColumn({ name: 'updated_at' })
+  updatedAt: Date;
+}

--- a/apps/backend/src/migrations/1775174400000-AddRoomsAndRoomMembers.ts
+++ b/apps/backend/src/migrations/1775174400000-AddRoomsAndRoomMembers.ts
@@ -1,0 +1,54 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+export class AddRoomsAndRoomMembers1775174400000 implements MigrationInterface {
+  name = 'AddRoomsAndRoomMembers1775174400000';
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`CREATE TYPE "room_member_role_enum" AS ENUM ('owner', 'member')`);
+
+    await queryRunner.query(`
+      CREATE TABLE "rooms" (
+        "id"           UUID DEFAULT gen_random_uuid() PRIMARY KEY,
+        "name"         VARCHAR NOT NULL,
+        "owner_id"     UUID NOT NULL REFERENCES "users"("id") ON DELETE CASCADE,
+        "invite_code"  VARCHAR NOT NULL UNIQUE,
+        "created_at"   TIMESTAMPTZ NOT NULL DEFAULT now(),
+        "updated_at"   TIMESTAMPTZ NOT NULL DEFAULT now()
+      )
+    `);
+
+    await queryRunner.query(`
+      CREATE TABLE "room_members" (
+        "id"        UUID DEFAULT gen_random_uuid() PRIMARY KEY,
+        "room_id"   UUID NOT NULL REFERENCES "rooms"("id") ON DELETE CASCADE,
+        "user_id"   UUID NOT NULL REFERENCES "users"("id") ON DELETE CASCADE,
+        "role"      "room_member_role_enum" NOT NULL,
+        "joined_at" TIMESTAMPTZ NOT NULL DEFAULT now()
+      )
+    `);
+
+    await queryRunner.query(`CREATE UNIQUE INDEX "idx_room_members_room_user" ON "room_members"("room_id", "user_id")`);
+    await queryRunner.query(`CREATE INDEX "idx_rooms_owner_id" ON "rooms"("owner_id")`);
+    await queryRunner.query(`CREATE INDEX "idx_room_members_room_id" ON "room_members"("room_id")`);
+    await queryRunner.query(`CREATE INDEX "idx_room_members_user_id" ON "room_members"("user_id")`);
+
+    await queryRunner.query(`
+      ALTER TABLE "receipts"
+      ADD COLUMN "room_id" UUID REFERENCES "rooms"("id") ON DELETE SET NULL
+    `);
+
+    await queryRunner.query(`CREATE INDEX "idx_receipts_room_id" ON "receipts"("room_id")`);
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`DROP INDEX "idx_receipts_room_id"`);
+    await queryRunner.query(`ALTER TABLE "receipts" DROP COLUMN "room_id"`);
+    await queryRunner.query(`DROP INDEX "idx_room_members_user_id"`);
+    await queryRunner.query(`DROP INDEX "idx_room_members_room_id"`);
+    await queryRunner.query(`DROP INDEX "idx_rooms_owner_id"`);
+    await queryRunner.query(`DROP INDEX "idx_room_members_room_user"`);
+    await queryRunner.query(`DROP TABLE "room_members"`);
+    await queryRunner.query(`DROP TABLE "rooms"`);
+    await queryRunner.query(`DROP TYPE "room_member_role_enum"`);
+  }
+}

--- a/apps/backend/src/receipts/receipts.controller.ts
+++ b/apps/backend/src/receipts/receipts.controller.ts
@@ -55,10 +55,12 @@ export class ReceiptsController {
       }),
     )
     file: Express.Multer.File,
+    @Body('roomId') roomId?: string,
   ): Promise<UploadReceiptResponseDto> {
     const receipt = await this.receiptsService.uploadReceipt({
       userId: user.id,
       file,
+      roomId,
     });
 
     return {
@@ -73,8 +75,9 @@ export class ReceiptsController {
   @Get()
   async listReceipts(
     @CurrentUser() user: User,
+    @Query('roomId') roomId?: string,
   ): Promise<ListReceiptsResponseDto> {
-    const receipts = await this.receiptsService.listReceipts(user.id);
+    const receipts = await this.receiptsService.listReceipts(user.id, roomId);
 
     return {
       items: receipts.map((r) => ({
@@ -95,8 +98,9 @@ export class ReceiptsController {
   async getYearlySummary(
     @CurrentUser() user: User,
     @Query('year', new DefaultValuePipe(new Date().getFullYear()), ParseIntPipe) year: number,
+    @Query('roomId') roomId?: string,
   ): Promise<YearlySummaryResponseDto> {
-    const summary = await this.receiptsService.getYearlySummary(user.id, year);
+    const summary = await this.receiptsService.getYearlySummary(user.id, year, roomId);
 
     return {
       year,
@@ -113,8 +117,9 @@ export class ReceiptsController {
     @CurrentUser() user: User,
     @Query('year', new DefaultValuePipe(new Date().getFullYear()), ParseIntPipe) year: number,
     @Query('month', new DefaultValuePipe(new Date().getMonth() + 1), ParseIntPipe) month: number,
+    @Query('roomId') roomId?: string,
   ): Promise<MonthlySummaryResponseDto> {
-    const summary = await this.receiptsService.getMonthlySummary(user.id, year, month);
+    const summary = await this.receiptsService.getMonthlySummary(user.id, year, month, roomId);
 
     return {
       year,

--- a/apps/backend/src/receipts/receipts.module.ts
+++ b/apps/backend/src/receipts/receipts.module.ts
@@ -3,6 +3,7 @@ import { TypeOrmModule } from '@nestjs/typeorm';
 import { AuthModule } from '../auth/auth.module';
 import { Receipt } from '../entities/receipt.entity';
 import { ReceiptItem } from '../entities/receipt-item.entity';
+import { RoomMember } from '../entities/room-member.entity';
 import { S3Module } from '../s3/s3.module';
 import { OpenAiModule } from '../openai/openai.module';
 import { ReceiptsController } from './receipts.controller';
@@ -10,7 +11,7 @@ import { ReceiptsService } from './receipts.service';
 
 @Module({
   imports: [
-    TypeOrmModule.forFeature([Receipt, ReceiptItem]),
+    TypeOrmModule.forFeature([Receipt, ReceiptItem, RoomMember]),
     S3Module,
     OpenAiModule,
     AuthModule,

--- a/apps/backend/src/receipts/receipts.service.ts
+++ b/apps/backend/src/receipts/receipts.service.ts
@@ -1,16 +1,18 @@
-import { Injectable, Logger, NotFoundException } from '@nestjs/common';
+import { ForbiddenException, Injectable, Logger, NotFoundException } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
 import { Repository } from 'typeorm';
 import { v4 as uuidv4 } from 'uuid';
 import sharp from 'sharp';
 import { Receipt, ReceiptStatus } from '../entities/receipt.entity';
 import { ReceiptItem } from '../entities/receipt-item.entity';
+import { RoomMember } from '../entities/room-member.entity';
 import { S3Service } from '../s3/s3.service';
 import { OpenAiService } from '../openai/openai.service';
 
 interface UploadReceiptParams {
   userId: string;
   file: Express.Multer.File;
+  roomId?: string;
 }
 
 @Injectable()
@@ -22,11 +24,23 @@ export class ReceiptsService {
     private readonly receiptsRepository: Repository<Receipt>,
     @InjectRepository(ReceiptItem)
     private readonly receiptItemsRepository: Repository<ReceiptItem>,
+    @InjectRepository(RoomMember)
+    private readonly roomMembersRepository: Repository<RoomMember>,
     private readonly s3Service: S3Service,
     private readonly openAiService: OpenAiService,
   ) {}
 
-  async uploadReceipt({ userId, file }: UploadReceiptParams): Promise<Receipt> {
+  async uploadReceipt({ userId, file, roomId }: UploadReceiptParams): Promise<Receipt> {
+    // roomIdが指定された場合のみメンバー確認を行う
+    if (roomId) {
+      const membership = await this.roomMembersRepository.findOne({
+        where: { roomId, userId },
+      });
+      if (!membership) {
+        throw new ForbiddenException('指定されたルームのメンバーではありません');
+      }
+    }
+
     // S3コスト・転送コスト削減のためWebP変換・リサイズ
     const { buffer: convertedBuffer, mimeType: convertedMimeType } =
       await this.convertToWebP(file.buffer);
@@ -44,6 +58,7 @@ export class ReceiptsService {
       s3Key,
       originalFileName: file.originalname,
       status: ReceiptStatus.PENDING,
+      roomId: roomId ?? null,
     });
 
     const saved = await this.receiptsRepository.save(receipt);
@@ -303,16 +318,23 @@ export class ReceiptsService {
     return this.s3Service.getPresignedUrl(receipt.s3Key);
   }
 
-  async listReceipts(userId: string): Promise<Receipt[]> {
-    return this.receiptsRepository.find({
-      where: { userId },
-      order: { createdAt: 'DESC' },
-    });
+  async listReceipts(userId: string, roomId?: string): Promise<Receipt[]> {
+    const qb = this.receiptsRepository
+      .createQueryBuilder('receipt')
+      .where('receipt.user_id = :userId', { userId })
+      .orderBy('receipt.created_at', 'DESC');
+
+    if (roomId) {
+      qb.andWhere('receipt.room_id = :roomId', { roomId });
+    }
+
+    return qb.getMany();
   }
 
   async getYearlySummary(
     userId: string,
     year: number,
+    roomId?: string,
   ): Promise<{
     total: number;
     currency: string;
@@ -332,72 +354,85 @@ export class ReceiptsService {
       total: string;
     };
 
+    const applyRoomFilter = <T extends object>(
+      qb: import('typeorm').SelectQueryBuilder<T>,
+    ) => {
+      if (roomId) {
+        qb.andWhere('receipt.room_id = :roomId', { roomId });
+      }
+      return qb;
+    };
+
     const [totalResult, byCategory, byMonth, byMonthCategory] =
       await Promise.all([
-        this.receiptsRepository
-          .createQueryBuilder('receipt')
-          .select('COALESCE(SUM(receipt.total), 0)', 'total')
-          .where('receipt.user_id = :userId', { userId })
-          .andWhere('receipt.status = :status', {
-            status: ReceiptStatus.COMPLETED,
-          })
-          .andWhere(
-            'receipt.purchased_at >= :from AND receipt.purchased_at < :to',
-            { from, to },
-          )
-          .getRawOne<RawTotal>(),
+        applyRoomFilter(
+          this.receiptsRepository
+            .createQueryBuilder('receipt')
+            .select('COALESCE(SUM(receipt.total), 0)', 'total')
+            .where('receipt.user_id = :userId', { userId })
+            .andWhere('receipt.status = :status', {
+              status: ReceiptStatus.COMPLETED,
+            })
+            .andWhere(
+              'receipt.purchased_at >= :from AND receipt.purchased_at < :to',
+              { from, to },
+            ),
+        ).getRawOne<RawTotal>(),
 
-        this.receiptItemsRepository
-          .createQueryBuilder('item')
-          .innerJoin('item.receipt', 'receipt')
-          .select('item.category', 'category')
-          .addSelect('SUM(item.total_price)', 'total')
-          .where('receipt.user_id = :userId', { userId })
-          .andWhere('receipt.status = :status', {
-            status: ReceiptStatus.COMPLETED,
-          })
-          .andWhere(
-            'receipt.purchased_at >= :from AND receipt.purchased_at < :to',
-            { from, to },
-          )
-          .groupBy('item.category')
-          .orderBy('total', 'DESC')
-          .getRawMany<RawCategoryTotal>(),
+        applyRoomFilter(
+          this.receiptItemsRepository
+            .createQueryBuilder('item')
+            .innerJoin('item.receipt', 'receipt')
+            .select('item.category', 'category')
+            .addSelect('SUM(item.total_price)', 'total')
+            .where('receipt.user_id = :userId', { userId })
+            .andWhere('receipt.status = :status', {
+              status: ReceiptStatus.COMPLETED,
+            })
+            .andWhere(
+              'receipt.purchased_at >= :from AND receipt.purchased_at < :to',
+              { from, to },
+            )
+            .groupBy('item.category')
+            .orderBy('total', 'DESC'),
+        ).getRawMany<RawCategoryTotal>(),
 
-        this.receiptsRepository
-          .createQueryBuilder('receipt')
-          .select('EXTRACT(MONTH FROM receipt.purchased_at)', 'month')
-          .addSelect('COALESCE(SUM(receipt.total), 0)', 'total')
-          .where('receipt.user_id = :userId', { userId })
-          .andWhere('receipt.status = :status', {
-            status: ReceiptStatus.COMPLETED,
-          })
-          .andWhere(
-            'receipt.purchased_at >= :from AND receipt.purchased_at < :to',
-            { from, to },
-          )
-          .groupBy('month')
-          .orderBy('month', 'ASC')
-          .getRawMany<RawMonthTotal>(),
+        applyRoomFilter(
+          this.receiptsRepository
+            .createQueryBuilder('receipt')
+            .select('EXTRACT(MONTH FROM receipt.purchased_at)', 'month')
+            .addSelect('COALESCE(SUM(receipt.total), 0)', 'total')
+            .where('receipt.user_id = :userId', { userId })
+            .andWhere('receipt.status = :status', {
+              status: ReceiptStatus.COMPLETED,
+            })
+            .andWhere(
+              'receipt.purchased_at >= :from AND receipt.purchased_at < :to',
+              { from, to },
+            )
+            .groupBy('month')
+            .orderBy('month', 'ASC'),
+        ).getRawMany<RawMonthTotal>(),
 
-        this.receiptItemsRepository
-          .createQueryBuilder('item')
-          .innerJoin('item.receipt', 'receipt')
-          .select('EXTRACT(MONTH FROM receipt.purchased_at)', 'month')
-          .addSelect('item.category', 'category')
-          .addSelect('SUM(item.total_price)', 'total')
-          .where('receipt.user_id = :userId', { userId })
-          .andWhere('receipt.status = :status', {
-            status: ReceiptStatus.COMPLETED,
-          })
-          .andWhere(
-            'receipt.purchased_at >= :from AND receipt.purchased_at < :to',
-            { from, to },
-          )
-          .groupBy('month')
-          .addGroupBy('item.category')
-          .orderBy('month', 'ASC')
-          .getRawMany<RawMonthCategoryTotal>(),
+        applyRoomFilter(
+          this.receiptItemsRepository
+            .createQueryBuilder('item')
+            .innerJoin('item.receipt', 'receipt')
+            .select('EXTRACT(MONTH FROM receipt.purchased_at)', 'month')
+            .addSelect('item.category', 'category')
+            .addSelect('SUM(item.total_price)', 'total')
+            .where('receipt.user_id = :userId', { userId })
+            .andWhere('receipt.status = :status', {
+              status: ReceiptStatus.COMPLETED,
+            })
+            .andWhere(
+              'receipt.purchased_at >= :from AND receipt.purchased_at < :to',
+              { from, to },
+            )
+            .groupBy('month')
+            .addGroupBy('item.category')
+            .orderBy('month', 'ASC'),
+        ).getRawMany<RawMonthCategoryTotal>(),
       ]);
 
     // 1〜12月すべてのエントリを返す（データなし月は0）
@@ -429,6 +464,7 @@ export class ReceiptsService {
     userId: string,
     year: number,
     month: number,
+    roomId?: string,
   ): Promise<{
     total: number;
     currency: string;
@@ -442,36 +478,42 @@ export class ReceiptsService {
     type RawTotal = { total: string };
     type RawCategoryTotal = { category: string | null; total: string };
 
-    const [totalResult, byCategory] = await Promise.all([
-      this.receiptsRepository
-        .createQueryBuilder('receipt')
-        .select('COALESCE(SUM(receipt.total), 0)', 'total')
-        .where('receipt.user_id = :userId', { userId })
-        .andWhere('receipt.status = :status', {
-          status: ReceiptStatus.COMPLETED,
-        })
-        .andWhere(
-          'receipt.purchased_at >= :from AND receipt.purchased_at < :to',
-          { from, to },
-        )
-        .getRawOne<RawTotal>(),
+    const totalQb = this.receiptsRepository
+      .createQueryBuilder('receipt')
+      .select('COALESCE(SUM(receipt.total), 0)', 'total')
+      .where('receipt.user_id = :userId', { userId })
+      .andWhere('receipt.status = :status', {
+        status: ReceiptStatus.COMPLETED,
+      })
+      .andWhere(
+        'receipt.purchased_at >= :from AND receipt.purchased_at < :to',
+        { from, to },
+      );
 
-      this.receiptItemsRepository
-        .createQueryBuilder('item')
-        .innerJoin('item.receipt', 'receipt')
-        .select('item.category', 'category')
-        .addSelect('SUM(item.total_price)', 'total')
-        .where('receipt.user_id = :userId', { userId })
-        .andWhere('receipt.status = :status', {
-          status: ReceiptStatus.COMPLETED,
-        })
-        .andWhere(
-          'receipt.purchased_at >= :from AND receipt.purchased_at < :to',
-          { from, to },
-        )
-        .groupBy('item.category')
-        .orderBy('total', 'DESC')
-        .getRawMany<RawCategoryTotal>(),
+    const categoryQb = this.receiptItemsRepository
+      .createQueryBuilder('item')
+      .innerJoin('item.receipt', 'receipt')
+      .select('item.category', 'category')
+      .addSelect('SUM(item.total_price)', 'total')
+      .where('receipt.user_id = :userId', { userId })
+      .andWhere('receipt.status = :status', {
+        status: ReceiptStatus.COMPLETED,
+      })
+      .andWhere(
+        'receipt.purchased_at >= :from AND receipt.purchased_at < :to',
+        { from, to },
+      )
+      .groupBy('item.category')
+      .orderBy('total', 'DESC');
+
+    if (roomId) {
+      totalQb.andWhere('receipt.room_id = :roomId', { roomId });
+      categoryQb.andWhere('receipt.room_id = :roomId', { roomId });
+    }
+
+    const [totalResult, byCategory] = await Promise.all([
+      totalQb.getRawOne<RawTotal>(),
+      categoryQb.getRawMany<RawCategoryTotal>(),
     ]);
 
     return {

--- a/apps/backend/src/rooms/dto/create-room.request.dto.ts
+++ b/apps/backend/src/rooms/dto/create-room.request.dto.ts
@@ -1,0 +1,3 @@
+export class CreateRoomRequestDto {
+  name: string;
+}

--- a/apps/backend/src/rooms/dto/join-room.request.dto.ts
+++ b/apps/backend/src/rooms/dto/join-room.request.dto.ts
@@ -1,0 +1,3 @@
+export class JoinRoomRequestDto {
+  inviteCode: string;
+}

--- a/apps/backend/src/rooms/dto/room-member.response.dto.ts
+++ b/apps/backend/src/rooms/dto/room-member.response.dto.ts
@@ -1,0 +1,10 @@
+import { RoomMemberRole } from '../../entities/room-member.entity';
+
+export class RoomMemberResponseDto {
+  id: string;
+  userId: string;
+  displayName: string | null;
+  avatarUrl: string | null;
+  role: RoomMemberRole;
+  joinedAt: Date;
+}

--- a/apps/backend/src/rooms/dto/room-receipt.response.dto.ts
+++ b/apps/backend/src/rooms/dto/room-receipt.response.dto.ts
@@ -1,0 +1,18 @@
+import { ReceiptStatus } from '../../entities/receipt.entity';
+
+export class RoomReceiptItemDto {
+  id: string;
+  userId: string;
+  uploaderDisplayName: string | null;
+  status: ReceiptStatus;
+  originalFileName: string;
+  storeName: string | null;
+  purchasedAt: Date | null;
+  total: number | null;
+  currency: string | null;
+  createdAt: Date;
+}
+
+export class ListRoomReceiptsResponseDto {
+  items: RoomReceiptItemDto[];
+}

--- a/apps/backend/src/rooms/dto/room.response.dto.ts
+++ b/apps/backend/src/rooms/dto/room.response.dto.ts
@@ -1,0 +1,18 @@
+import { RoomMemberResponseDto } from './room-member.response.dto';
+
+export class RoomResponseDto {
+  id: string;
+  name: string;
+  ownerId: string;
+  memberCount: number;
+  createdAt: Date;
+}
+
+export class RoomDetailResponseDto {
+  id: string;
+  name: string;
+  ownerId: string;
+  inviteCode: string | null;
+  members: RoomMemberResponseDto[];
+  createdAt: Date;
+}

--- a/apps/backend/src/rooms/rooms.controller.ts
+++ b/apps/backend/src/rooms/rooms.controller.ts
@@ -1,0 +1,95 @@
+import {
+  Body,
+  Controller,
+  Delete,
+  Get,
+  HttpCode,
+  Param,
+  ParseUUIDPipe,
+  Post,
+  UseGuards,
+} from '@nestjs/common';
+import { JwtAuthGuard } from '../auth/guards/jwt-auth.guard';
+import { CurrentUser } from '../common/decorators/current-user.decorator';
+import { User } from '../entities/user.entity';
+import { RoomMemberRole } from '../entities/room-member.entity';
+import { CreateRoomRequestDto } from './dto/create-room.request.dto';
+import { RoomDetailResponseDto, RoomResponseDto } from './dto/room.response.dto';
+import { RoomsService } from './rooms.service';
+
+@Controller('rooms')
+@UseGuards(JwtAuthGuard)
+export class RoomsController {
+  constructor(private readonly roomsService: RoomsService) {}
+
+  @Post()
+  async createRoom(
+    @CurrentUser() user: User,
+    @Body() body: CreateRoomRequestDto,
+  ): Promise<RoomResponseDto> {
+    const room = await this.roomsService.createRoom(user.id, body.name);
+    return {
+      id: room.id,
+      name: room.name,
+      ownerId: room.ownerId,
+      memberCount: 1,
+      createdAt: room.createdAt,
+    };
+  }
+
+  @Get()
+  async listRooms(@CurrentUser() user: User): Promise<RoomResponseDto[]> {
+    const rooms = await this.roomsService.listRooms(user.id);
+    return rooms.map((room) => ({
+      id: room.id,
+      name: room.name,
+      ownerId: room.ownerId,
+      memberCount: room.members?.length ?? 0,
+      createdAt: room.createdAt,
+    }));
+  }
+
+  @Get(':id')
+  async getRoom(
+    @CurrentUser() user: User,
+    @Param('id', ParseUUIDPipe) id: string,
+  ): Promise<RoomDetailResponseDto> {
+    const { room, member } = await this.roomsService.getRoom(id, user.id);
+    const isOwner = member.role === RoomMemberRole.OWNER;
+
+    return {
+      id: room.id,
+      name: room.name,
+      ownerId: room.ownerId,
+      // 招待コードはオーナーにのみ開示する
+      inviteCode: isOwner ? room.inviteCode : null,
+      members: room.members.map((m) => ({
+        id: m.id,
+        userId: m.userId,
+        displayName: m.user?.displayName ?? null,
+        avatarUrl: m.user?.avatarUrl ?? null,
+        role: m.role,
+        joinedAt: m.joinedAt,
+      })),
+      createdAt: room.createdAt,
+    };
+  }
+
+  @Delete(':id')
+  @HttpCode(204)
+  async deleteRoom(
+    @CurrentUser() user: User,
+    @Param('id', ParseUUIDPipe) id: string,
+  ): Promise<void> {
+    await this.roomsService.deleteRoom(id, user.id);
+  }
+
+  @Delete(':id/members/me')
+  @HttpCode(204)
+  async leaveRoom(
+    @CurrentUser() user: User,
+    @Param('id', ParseUUIDPipe) id: string,
+  ): Promise<void> {
+    await this.roomsService.leaveRoom(id, user.id);
+  }
+}

--- a/apps/backend/src/rooms/rooms.controller.ts
+++ b/apps/backend/src/rooms/rooms.controller.ts
@@ -16,6 +16,7 @@ import { RoomMemberRole } from '../entities/room-member.entity';
 import { CreateRoomRequestDto } from './dto/create-room.request.dto';
 import { JoinRoomRequestDto } from './dto/join-room.request.dto';
 import { RoomDetailResponseDto, RoomResponseDto } from './dto/room.response.dto';
+import { ListRoomReceiptsResponseDto } from './dto/room-receipt.response.dto';
 import { RoomsService } from './rooms.service';
 
 @Controller('rooms')
@@ -73,6 +74,28 @@ export class RoomsController {
   ): Promise<{ inviteCode: string }> {
     const room = await this.roomsService.regenerateInviteCode(id, user.id);
     return { inviteCode: room.inviteCode };
+  }
+
+  @Get(':id/receipts')
+  async listRoomReceipts(
+    @CurrentUser() user: User,
+    @Param('id', ParseUUIDPipe) id: string,
+  ): Promise<ListRoomReceiptsResponseDto> {
+    const receipts = await this.roomsService.listRoomReceipts(id, user.id);
+    return {
+      items: receipts.map((r) => ({
+        id: r.id,
+        userId: r.userId,
+        uploaderDisplayName: r.user?.displayName ?? null,
+        status: r.status,
+        originalFileName: r.originalFileName,
+        storeName: r.storeName,
+        purchasedAt: r.purchasedAt,
+        total: r.total !== null ? Number(r.total) : null,
+        currency: r.currency,
+        createdAt: r.createdAt,
+      })),
+    };
   }
 
   @Get(':id')

--- a/apps/backend/src/rooms/rooms.controller.ts
+++ b/apps/backend/src/rooms/rooms.controller.ts
@@ -14,6 +14,7 @@ import { CurrentUser } from '../common/decorators/current-user.decorator';
 import { User } from '../entities/user.entity';
 import { RoomMemberRole } from '../entities/room-member.entity';
 import { CreateRoomRequestDto } from './dto/create-room.request.dto';
+import { JoinRoomRequestDto } from './dto/join-room.request.dto';
 import { RoomDetailResponseDto, RoomResponseDto } from './dto/room.response.dto';
 import { RoomsService } from './rooms.service';
 
@@ -47,6 +48,31 @@ export class RoomsController {
       memberCount: room.members?.length ?? 0,
       createdAt: room.createdAt,
     }));
+  }
+
+  // GET /rooms/:id との競合を避けるため /rooms/join を先に定義
+  @Post('join')
+  async joinRoom(
+    @CurrentUser() user: User,
+    @Body() body: JoinRoomRequestDto,
+  ): Promise<RoomResponseDto> {
+    const room = await this.roomsService.joinRoom(user.id, body.inviteCode);
+    return {
+      id: room.id,
+      name: room.name,
+      ownerId: room.ownerId,
+      memberCount: room.members?.length ?? 0,
+      createdAt: room.createdAt,
+    };
+  }
+
+  @Post(':id/invite-code/regenerate')
+  async regenerateInviteCode(
+    @CurrentUser() user: User,
+    @Param('id', ParseUUIDPipe) id: string,
+  ): Promise<{ inviteCode: string }> {
+    const room = await this.roomsService.regenerateInviteCode(id, user.id);
+    return { inviteCode: room.inviteCode };
   }
 
   @Get(':id')

--- a/apps/backend/src/rooms/rooms.module.ts
+++ b/apps/backend/src/rooms/rooms.module.ts
@@ -3,12 +3,13 @@ import { TypeOrmModule } from '@nestjs/typeorm';
 import { AuthModule } from '../auth/auth.module';
 import { Room } from '../entities/room.entity';
 import { RoomMember } from '../entities/room-member.entity';
+import { Receipt } from '../entities/receipt.entity';
 import { RoomsController } from './rooms.controller';
 import { RoomsService } from './rooms.service';
 
 @Module({
   imports: [
-    TypeOrmModule.forFeature([Room, RoomMember]),
+    TypeOrmModule.forFeature([Room, RoomMember, Receipt]),
     AuthModule,
   ],
   controllers: [RoomsController],

--- a/apps/backend/src/rooms/rooms.module.ts
+++ b/apps/backend/src/rooms/rooms.module.ts
@@ -3,13 +3,12 @@ import { TypeOrmModule } from '@nestjs/typeorm';
 import { AuthModule } from '../auth/auth.module';
 import { Room } from '../entities/room.entity';
 import { RoomMember } from '../entities/room-member.entity';
-import { User } from '../entities/user.entity';
 import { RoomsController } from './rooms.controller';
 import { RoomsService } from './rooms.service';
 
 @Module({
   imports: [
-    TypeOrmModule.forFeature([Room, RoomMember, User]),
+    TypeOrmModule.forFeature([Room, RoomMember]),
     AuthModule,
   ],
   controllers: [RoomsController],

--- a/apps/backend/src/rooms/rooms.module.ts
+++ b/apps/backend/src/rooms/rooms.module.ts
@@ -1,0 +1,19 @@
+import { Module } from '@nestjs/common';
+import { TypeOrmModule } from '@nestjs/typeorm';
+import { AuthModule } from '../auth/auth.module';
+import { Room } from '../entities/room.entity';
+import { RoomMember } from '../entities/room-member.entity';
+import { User } from '../entities/user.entity';
+import { RoomsController } from './rooms.controller';
+import { RoomsService } from './rooms.service';
+
+@Module({
+  imports: [
+    TypeOrmModule.forFeature([Room, RoomMember, User]),
+    AuthModule,
+  ],
+  controllers: [RoomsController],
+  providers: [RoomsService],
+  exports: [RoomsService],
+})
+export class RoomsModule {}

--- a/apps/backend/src/rooms/rooms.service.ts
+++ b/apps/backend/src/rooms/rooms.service.ts
@@ -8,6 +8,7 @@ import { InjectRepository } from '@nestjs/typeorm';
 import { Repository } from 'typeorm';
 import { Room } from '../entities/room.entity';
 import { RoomMember, RoomMemberRole } from '../entities/room-member.entity';
+import { Receipt } from '../entities/receipt.entity';
 @Injectable()
 export class RoomsService {
   constructor(
@@ -15,6 +16,8 @@ export class RoomsService {
     private readonly roomsRepository: Repository<Room>,
     @InjectRepository(RoomMember)
     private readonly roomMembersRepository: Repository<RoomMember>,
+    @InjectRepository(Receipt)
+    private readonly receiptsRepository: Repository<Receipt>,
   ) {}
 
   async createRoom(userId: string, name: string): Promise<Room> {
@@ -136,6 +139,24 @@ export class RoomsService {
 
     room.inviteCode = this.generateInviteCode();
     return this.roomsRepository.save(room);
+  }
+
+  async listRoomReceipts(roomId: string, userId: string): Promise<Receipt[]> {
+    // メンバー確認
+    const member = await this.roomMembersRepository.findOne({
+      where: { roomId, userId },
+    });
+    if (!member) {
+      throw new NotFoundException(`ルームが見つかりません: ${roomId}`);
+    }
+
+    // ルームに紐づく全メンバーのレシートをuserと一緒に取得
+    return this.receiptsRepository
+      .createQueryBuilder('receipt')
+      .innerJoinAndSelect('receipt.user', 'user')
+      .where('receipt.room_id = :roomId', { roomId })
+      .orderBy('receipt.created_at', 'DESC')
+      .getMany();
   }
 
   private generateInviteCode(): string {

--- a/apps/backend/src/rooms/rooms.service.ts
+++ b/apps/backend/src/rooms/rooms.service.ts
@@ -1,4 +1,5 @@
 import {
+  ConflictException,
   ForbiddenException,
   Injectable,
   NotFoundException,
@@ -94,6 +95,47 @@ export class RoomsService {
     }
 
     await this.roomMembersRepository.remove(member);
+  }
+
+  async joinRoom(userId: string, inviteCode: string): Promise<Room> {
+    const room = await this.roomsRepository.findOne({ where: { inviteCode } });
+    if (!room) {
+      throw new NotFoundException('招待コードが無効です');
+    }
+
+    const existing = await this.roomMembersRepository.findOne({
+      where: { roomId: room.id, userId },
+    });
+    if (existing) {
+      throw new ConflictException('既にこのルームのメンバーです');
+    }
+
+    const member = this.roomMembersRepository.create({
+      roomId: room.id,
+      userId,
+      role: RoomMemberRole.MEMBER,
+    });
+    await this.roomMembersRepository.save(member);
+
+    return room;
+  }
+
+  async regenerateInviteCode(roomId: string, userId: string): Promise<Room> {
+    const member = await this.roomMembersRepository.findOne({
+      where: { roomId, userId },
+    });
+    // 招待コード再生成はオーナーのみ許可
+    if (!member || member.role !== RoomMemberRole.OWNER) {
+      throw new ForbiddenException('招待コードの再生成はオーナーのみ可能です');
+    }
+
+    const room = await this.roomsRepository.findOne({ where: { id: roomId } });
+    if (!room) {
+      throw new NotFoundException(`ルームが見つかりません: ${roomId}`);
+    }
+
+    room.inviteCode = this.generateInviteCode();
+    return this.roomsRepository.save(room);
   }
 
   private generateInviteCode(): string {

--- a/apps/backend/src/rooms/rooms.service.ts
+++ b/apps/backend/src/rooms/rooms.service.ts
@@ -1,0 +1,110 @@
+import {
+  ForbiddenException,
+  Injectable,
+  NotFoundException,
+} from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Repository } from 'typeorm';
+import { Room } from '../entities/room.entity';
+import { RoomMember, RoomMemberRole } from '../entities/room-member.entity';
+import { User } from '../entities/user.entity';
+
+@Injectable()
+export class RoomsService {
+  constructor(
+    @InjectRepository(Room)
+    private readonly roomsRepository: Repository<Room>,
+    @InjectRepository(RoomMember)
+    private readonly roomMembersRepository: Repository<RoomMember>,
+    @InjectRepository(User)
+    private readonly usersRepository: Repository<User>,
+  ) {}
+
+  async createRoom(userId: string, name: string): Promise<Room> {
+    const inviteCode = this.generateInviteCode();
+
+    const room = this.roomsRepository.create({ name, ownerId: userId, inviteCode });
+    const saved = await this.roomsRepository.save(room);
+
+    const member = this.roomMembersRepository.create({
+      roomId: saved.id,
+      userId,
+      role: RoomMemberRole.OWNER,
+    });
+    await this.roomMembersRepository.save(member);
+
+    return saved;
+  }
+
+  async listRooms(userId: string): Promise<Room[]> {
+    return this.roomsRepository
+      .createQueryBuilder('room')
+      .innerJoin('room.members', 'member')
+      .where('member.user_id = :userId', { userId })
+      .orderBy('room.created_at', 'DESC')
+      .getMany();
+  }
+
+  async getRoom(
+    roomId: string,
+    userId: string,
+  ): Promise<{ room: Room; member: RoomMember }> {
+    const member = await this.roomMembersRepository.findOne({
+      where: { roomId, userId },
+    });
+    if (!member) {
+      throw new NotFoundException(`ルームが見つかりません: ${roomId}`);
+    }
+
+    const room = await this.roomsRepository.findOne({
+      where: { id: roomId },
+      relations: ['members', 'members.user'],
+    });
+    if (!room) {
+      throw new NotFoundException(`ルームが見つかりません: ${roomId}`);
+    }
+
+    return { room, member };
+  }
+
+  async deleteRoom(roomId: string, userId: string): Promise<void> {
+    const member = await this.roomMembersRepository.findOne({
+      where: { roomId, userId },
+    });
+    // オーナー以外はルームを解散できない
+    if (!member || member.role !== RoomMemberRole.OWNER) {
+      throw new ForbiddenException('ルームの解散はオーナーのみ可能です');
+    }
+
+    const room = await this.roomsRepository.findOne({ where: { id: roomId } });
+    if (!room) {
+      throw new NotFoundException(`ルームが見つかりません: ${roomId}`);
+    }
+    await this.roomsRepository.remove(room);
+  }
+
+  async leaveRoom(roomId: string, userId: string): Promise<void> {
+    const member = await this.roomMembersRepository.findOne({
+      where: { roomId, userId },
+    });
+    if (!member) {
+      throw new NotFoundException(`ルームが見つかりません: ${roomId}`);
+    }
+    // オーナーが退出するとルームが宙に浮くため禁止
+    if (member.role === RoomMemberRole.OWNER) {
+      throw new ForbiddenException(
+        'オーナーはルームを退出できません。ルームを解散してください',
+      );
+    }
+
+    await this.roomMembersRepository.remove(member);
+  }
+
+  private generateInviteCode(): string {
+    const chars =
+      'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789';
+    return Array.from({ length: 8 }, () =>
+      chars.charAt(Math.floor(Math.random() * chars.length)),
+    ).join('');
+  }
+}

--- a/apps/backend/src/rooms/rooms.service.ts
+++ b/apps/backend/src/rooms/rooms.service.ts
@@ -7,8 +7,6 @@ import { InjectRepository } from '@nestjs/typeorm';
 import { Repository } from 'typeorm';
 import { Room } from '../entities/room.entity';
 import { RoomMember, RoomMemberRole } from '../entities/room-member.entity';
-import { User } from '../entities/user.entity';
-
 @Injectable()
 export class RoomsService {
   constructor(
@@ -16,8 +14,6 @@ export class RoomsService {
     private readonly roomsRepository: Repository<Room>,
     @InjectRepository(RoomMember)
     private readonly roomMembersRepository: Repository<RoomMember>,
-    @InjectRepository(User)
-    private readonly usersRepository: Repository<User>,
   ) {}
 
   async createRoom(userId: string, name: string): Promise<Room> {

--- a/apps/frontend/src/app/dashboard/_components/ReceiptUploadCard.tsx
+++ b/apps/frontend/src/app/dashboard/_components/ReceiptUploadCard.tsx
@@ -3,6 +3,7 @@
 import { DragEvent, ChangeEvent, useEffect, useRef, useState } from 'react';
 import Link from 'next/link';
 import { getReceipt, uploadReceipt } from '../../../lib/api/receipts';
+import { Room } from '../../../types/room';
 
 const POLL_INTERVAL_MS = 2000;
 const POLL_TIMEOUT_MS = 120_000;
@@ -26,14 +27,18 @@ type UploadState =
 
 interface ReceiptUploadCardProps {
   backendToken: string;
+  rooms?: Room[];
 }
 
 const TERMINAL_STATUSES: FileItemStatus[] = ['success', 'duplicate-warning', 'analysis-failed'];
 
-export function ReceiptUploadCard({ backendToken }: ReceiptUploadCardProps) {
+export function ReceiptUploadCard({ backendToken, rooms }: ReceiptUploadCardProps) {
   const [uploadState, setUploadState] = useState<UploadState>({ status: 'idle' });
   const [isDragging, setIsDragging] = useState(false);
+  const [selectedRoomId, setSelectedRoomId] = useState<string | null>(null);
   const inputRef = useRef<HTMLInputElement>(null);
+
+  const hasRooms = rooms !== undefined && rooms.length > 0;
 
   const updateFile = (key: string, patch: Partial<Omit<FileItem, 'key'>>) => {
     setUploadState((prev) => {
@@ -48,9 +53,9 @@ export function ReceiptUploadCard({ backendToken }: ReceiptUploadCardProps) {
     });
   };
 
-  const processFile = async (file: File, key: string): Promise<void> => {
+  const processFile = async (file: File, key: string, roomId: string | undefined): Promise<void> => {
     try {
-      const result = await uploadReceipt(file, backendToken);
+      const result = await uploadReceipt(file, backendToken, roomId);
       updateFile(key, { status: 'analyzing', receiptId: result.id });
 
       const deadline = Date.now() + POLL_TIMEOUT_MS;
@@ -98,8 +103,10 @@ export function ReceiptUploadCard({ backendToken }: ReceiptUploadCardProps) {
 
     setUploadState({ status: 'processing', files: items });
 
+    // アップロード開始時点のroomIdをキャプチャして全ファイルに適用する
+    const roomIdSnapshot = selectedRoomId ?? undefined;
     files.forEach((file, i) => {
-      processFile(file, items[i].key);
+      processFile(file, items[i].key, roomIdSnapshot);
     });
   };
 
@@ -133,6 +140,30 @@ export function ReceiptUploadCard({ backendToken }: ReceiptUploadCardProps) {
       <h2 className="mb-6 text-lg font-semibold text-zinc-900 dark:text-zinc-50">
         レシートをアップロード
       </h2>
+
+      {hasRooms && (
+        <div className="mb-4">
+          <label
+            htmlFor="room-select"
+            className="mb-1 block text-sm font-medium text-zinc-700 dark:text-zinc-300"
+          >
+            投稿先
+          </label>
+          <select
+            id="room-select"
+            value={selectedRoomId ?? ''}
+            onChange={(e) => setSelectedRoomId(e.target.value || null)}
+            className="w-full rounded-lg border border-zinc-300 bg-white px-3 py-2 text-sm text-zinc-900 focus:border-zinc-500 focus:outline-none dark:border-zinc-700 dark:bg-zinc-800 dark:text-zinc-50 dark:focus:border-zinc-400"
+          >
+            <option value="">個人</option>
+            {rooms.map((room) => (
+              <option key={room.id} value={room.id}>
+                {room.name}
+              </option>
+            ))}
+          </select>
+        </div>
+      )}
 
       {uploadState.status === 'processing' || uploadState.status === 'done' ? (
         <div className="flex flex-col gap-3">

--- a/apps/frontend/src/app/receipts/_components/ReceiptList.tsx
+++ b/apps/frontend/src/app/receipts/_components/ReceiptList.tsx
@@ -7,9 +7,13 @@ import { type UpdateReceiptItemRequest, ListReceiptItem, GetReceiptDetailRespons
 import { getReceiptDetail, updateReceipt, deleteReceipt } from '../../../lib/api/receipts';
 import { ReceiptDetailContent } from '../../../components/ReceiptDetailContent';
 
+// RoomReceiptItemにはpossibleDuplicateIdsがないため、ReceiptListでも共通して扱えるようオプショナルに拡張
+type ReceiptListItem = ListReceiptItem & { uploaderDisplayName?: string | null };
+
 interface ReceiptListProps {
-  receipts: ListReceiptItem[];
+  receipts: ReceiptListItem[];
   backendToken: string;
+  showUploader?: boolean;
 }
 
 const STATUS_LABELS: Record<ListReceiptItem['status'], string> = {
@@ -136,13 +140,14 @@ function EditModal({ receiptId, backendToken, onClose, onSaved }: EditModalProps
 // ---- レシート行 ----
 
 interface ReceiptRowProps {
-  receipt: ListReceiptItem;
+  receipt: ReceiptListItem;
   isLast: boolean;
+  showUploader?: boolean;
   onEdit: (id: string) => void;
   onDelete: (id: string) => void;
 }
 
-function ReceiptRow({ receipt, isLast, onEdit, onDelete }: ReceiptRowProps) {
+function ReceiptRow({ receipt, isLast, showUploader, onEdit, onDelete }: ReceiptRowProps) {
   const [confirmDelete, setConfirmDelete] = useState(false);
   const [isDeleting, startTransition] = useTransition();
 
@@ -179,6 +184,11 @@ function ReceiptRow({ receipt, isLast, onEdit, onDelete }: ReceiptRowProps) {
                   : STATUS_LABELS[receipt.status]}
               </span>
             </div>
+            {showUploader && receipt.uploaderDisplayName && (
+              <p className="mt-0.5 text-xs text-zinc-400 dark:text-zinc-600">
+                {receipt.uploaderDisplayName}
+              </p>
+            )}
           </div>
           <span className="ml-2 shrink-0 self-center text-zinc-300 dark:text-zinc-600">›</span>
         </Link>
@@ -226,7 +236,7 @@ function ReceiptRow({ receipt, isLast, onEdit, onDelete }: ReceiptRowProps) {
 
 // ---- メインコンポーネント ----
 
-export function ReceiptList({ receipts: initial, backendToken }: ReceiptListProps) {
+export function ReceiptList({ receipts: initial, backendToken, showUploader }: ReceiptListProps) {
   const router = useRouter();
   const [receipts, setReceipts] = useState(initial);
   const [editTargetId, setEditTargetId] = useState<string | null>(null);
@@ -262,6 +272,7 @@ export function ReceiptList({ receipts: initial, backendToken }: ReceiptListProp
             key={receipt.id}
             receipt={receipt}
             isLast={idx === receipts.length - 1}
+            showUploader={showUploader}
             onEdit={setEditTargetId}
             onDelete={handleDelete}
           />

--- a/apps/frontend/src/app/receipts/_components/ReceiptTabs.tsx
+++ b/apps/frontend/src/app/receipts/_components/ReceiptTabs.tsx
@@ -1,0 +1,47 @@
+'use client';
+
+import { useRouter } from 'next/navigation';
+import { Room } from '../../../types/room';
+
+interface ReceiptTabsProps {
+  rooms: Room[];
+  currentRoomId: string | null;
+}
+
+export function ReceiptTabs({ rooms, currentRoomId }: ReceiptTabsProps) {
+  const router = useRouter();
+
+  const tabs = [
+    { label: '個人', roomId: null },
+    ...rooms.map((room) => ({ label: room.name, roomId: room.id })),
+  ];
+
+  const handleTabClick = (roomId: string | null) => {
+    if (roomId === null) {
+      router.push('/receipts');
+    } else {
+      router.push(`/receipts?roomId=${roomId}`);
+    }
+  };
+
+  return (
+    <div className="flex gap-1 border-b border-zinc-100 px-4 sm:px-8 dark:border-zinc-800">
+      {tabs.map((tab) => {
+        const isActive = tab.roomId === currentRoomId;
+        return (
+          <button
+            key={tab.roomId ?? '__personal__'}
+            onClick={() => handleTabClick(tab.roomId)}
+            className={`px-3 py-3 text-sm font-medium transition-colors border-b-2 -mb-px ${
+              isActive
+                ? 'border-zinc-900 text-zinc-900 dark:border-zinc-50 dark:text-zinc-50'
+                : 'border-transparent text-zinc-400 hover:text-zinc-700 dark:hover:text-zinc-300'
+            }`}
+          >
+            {tab.label}
+          </button>
+        );
+      })}
+    </div>
+  );
+}

--- a/apps/frontend/src/app/receipts/page.tsx
+++ b/apps/frontend/src/app/receipts/page.tsx
@@ -3,29 +3,59 @@ import { redirect } from 'next/navigation';
 import { AppHeader } from '../../components/AppHeader';
 import { ReceiptUploadCard } from '../dashboard/_components/ReceiptUploadCard';
 import { ReceiptList } from './_components/ReceiptList';
+import { ReceiptTabs } from './_components/ReceiptTabs';
 import { listReceipts } from '../../lib/api/receipts';
+import { getRooms, listRoomReceipts } from '../../lib/api/rooms';
 import { ListReceiptItem } from '../../types/receipt';
+import { RoomReceiptItem } from '../../types/room';
 
-export default async function ReceiptsPage() {
+// RoomReceiptItemはpossibleDuplicateIdsを持たないため、ReceiptListItemにマッピングして渡す
+function toReceiptListItem(item: RoomReceiptItem): ListReceiptItem & { uploaderDisplayName?: string | null } {
+  return {
+    id: item.id,
+    status: item.status,
+    originalFileName: item.originalFileName,
+    storeName: item.storeName,
+    purchasedAt: item.purchasedAt,
+    total: item.total,
+    currency: item.currency,
+    possibleDuplicateIds: null,
+    createdAt: item.createdAt,
+    uploaderDisplayName: item.uploaderDisplayName,
+  };
+}
+
+interface ReceiptsPageProps {
+  searchParams: Promise<{ roomId?: string }>;
+}
+
+export default async function ReceiptsPage({ searchParams }: ReceiptsPageProps) {
   const session = await auth();
 
   if (!session) {
     redirect('/');
   }
 
-  let receipts: ListReceiptItem[] = [];
-  try {
-    const data = await listReceipts(session.backendToken);
-    receipts = data.items;
-  } catch {
-    // 取得失敗時は空配列のまま
-  }
+  const { roomId } = await searchParams;
+
+  const [rooms, receipts] = await Promise.all([
+    getRooms(session.backendToken).catch(() => []),
+    roomId
+      ? listRoomReceipts(roomId, session.backendToken)
+          .then((items) => items.map(toReceiptListItem))
+          .catch(() => [] as ReturnType<typeof toReceiptListItem>[])
+      : listReceipts(session.backendToken)
+          .then((data) => data.items)
+          .catch(() => [] as ListReceiptItem[]),
+  ]);
 
   return (
     <div className="min-h-screen bg-zinc-50 dark:bg-black">
       <AppHeader currentPath="/receipts" />
 
       <main className="mx-auto max-w-4xl space-y-6 px-4 py-6 sm:px-6 sm:py-10">
+        <ReceiptTabs rooms={rooms} currentRoomId={roomId ?? null} />
+
         <ReceiptUploadCard backendToken={session.backendToken} />
 
         <div className="rounded-2xl bg-white shadow-sm dark:bg-zinc-900">
@@ -34,7 +64,11 @@ export default async function ReceiptsPage() {
               レシート一覧
             </h2>
           </div>
-          <ReceiptList receipts={receipts} backendToken={session.backendToken} />
+          <ReceiptList
+            receipts={receipts}
+            backendToken={session.backendToken}
+            showUploader={!!roomId}
+          />
         </div>
       </main>
     </div>

--- a/apps/frontend/src/app/receipts/page.tsx
+++ b/apps/frontend/src/app/receipts/page.tsx
@@ -56,7 +56,7 @@ export default async function ReceiptsPage({ searchParams }: ReceiptsPageProps) 
       <main className="mx-auto max-w-4xl space-y-6 px-4 py-6 sm:px-6 sm:py-10">
         <ReceiptTabs rooms={rooms} currentRoomId={roomId ?? null} />
 
-        <ReceiptUploadCard backendToken={session.backendToken} />
+        <ReceiptUploadCard backendToken={session.backendToken} rooms={rooms} />
 
         <div className="rounded-2xl bg-white shadow-sm dark:bg-zinc-900">
           <div className="border-b border-zinc-100 px-4 py-4 sm:px-8 sm:py-5 dark:border-zinc-800">

--- a/apps/frontend/src/app/rooms/_components/RoomCard.tsx
+++ b/apps/frontend/src/app/rooms/_components/RoomCard.tsx
@@ -1,0 +1,22 @@
+import { Room } from '../../../types/room';
+
+interface RoomCardProps {
+  room: Room;
+}
+
+export function RoomCard({ room }: RoomCardProps) {
+  return (
+    <li className="border-b border-zinc-100 last:border-b-0 dark:border-zinc-800">
+      <div className="flex items-center px-4 py-4 sm:px-8">
+        <div className="min-w-0 flex-1">
+          <p className="truncate text-sm font-medium text-zinc-900 dark:text-zinc-50">
+            {room.name}
+          </p>
+          <p className="mt-0.5 text-xs text-zinc-400 dark:text-zinc-600">
+            {room.memberCount}人のメンバー
+          </p>
+        </div>
+      </div>
+    </li>
+  );
+}

--- a/apps/frontend/src/app/rooms/_components/RoomCreateModal.tsx
+++ b/apps/frontend/src/app/rooms/_components/RoomCreateModal.tsx
@@ -1,0 +1,107 @@
+'use client';
+
+import { useState, useTransition, FormEvent } from 'react';
+import { Room } from '../../../types/room';
+import { createRoom } from '../../../lib/api/rooms';
+
+interface RoomCreateModalProps {
+  backendToken: string;
+  onCreated: (room: Room) => void;
+  onClose: () => void;
+}
+
+export function RoomCreateModal({ backendToken, onCreated, onClose }: RoomCreateModalProps) {
+  const [name, setName] = useState('');
+  const [error, setError] = useState('');
+  const [isPending, startTransition] = useTransition();
+
+  const handleSubmit = (e: FormEvent<HTMLFormElement>) => {
+    e.preventDefault();
+    if (!name.trim()) return;
+
+    startTransition(async () => {
+      setError('');
+      try {
+        const room = await createRoom(name.trim(), backendToken);
+        onCreated(room);
+      } catch (err) {
+        setError(err instanceof Error ? err.message : 'ルームの作成に失敗しました');
+      }
+    });
+  };
+
+  return (
+    <div
+      className="fixed inset-0 z-50 flex items-start justify-center overflow-y-auto bg-black/40 p-4 py-10 backdrop-blur-sm"
+      onClick={(e) => { if (e.target === e.currentTarget) onClose(); }}
+    >
+      <div className="w-full max-w-md">
+        <div className="mb-4 flex items-center justify-between">
+          <h3 className="text-base font-semibold text-white">ルームを作成</h3>
+          <button
+            onClick={onClose}
+            className="rounded-lg p-1.5 text-zinc-300 transition-colors hover:bg-white/10 hover:text-white"
+            aria-label="閉じる"
+          >
+            <CloseIcon />
+          </button>
+        </div>
+
+        <div className="rounded-2xl bg-white p-6 shadow-sm dark:bg-zinc-900">
+          <form onSubmit={handleSubmit} className="space-y-4">
+            <div>
+              <label
+                htmlFor="room-name"
+                className="mb-1.5 block text-sm font-medium text-zinc-700 dark:text-zinc-300"
+              >
+                ルーム名
+              </label>
+              <input
+                id="room-name"
+                type="text"
+                value={name}
+                onChange={(e) => setName(e.target.value)}
+                placeholder="例：家族の支出管理"
+                disabled={isPending}
+                className="w-full rounded-lg border border-zinc-200 bg-white px-3 py-2 text-sm text-zinc-900 placeholder-zinc-400 outline-none transition-colors focus:border-zinc-400 disabled:opacity-50 dark:border-zinc-700 dark:bg-zinc-800 dark:text-zinc-50 dark:placeholder-zinc-600 dark:focus:border-zinc-500"
+              />
+            </div>
+
+            {error && (
+              <p className="text-sm text-red-500">{error}</p>
+            )}
+
+            <div className="flex justify-end gap-2">
+              <button
+                type="button"
+                onClick={onClose}
+                disabled={isPending}
+                className="rounded-lg px-4 py-2 text-sm text-zinc-500 transition-colors hover:text-zinc-900 disabled:opacity-50 dark:text-zinc-400 dark:hover:text-zinc-50"
+              >
+                キャンセル
+              </button>
+              <button
+                type="submit"
+                disabled={isPending || !name.trim()}
+                className="rounded-lg bg-zinc-900 px-4 py-2 text-sm font-medium text-white transition-colors hover:bg-zinc-700 disabled:opacity-50 dark:bg-zinc-50 dark:text-zinc-900 dark:hover:bg-zinc-200"
+              >
+                {isPending ? '作成中…' : '作成'}
+              </button>
+            </div>
+          </form>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+function CloseIcon() {
+  return (
+    <svg width="15" height="15" viewBox="0 0 15 15" fill="none" xmlns="http://www.w3.org/2000/svg">
+      <path
+        d="M11.782 4.032a.575.575 0 1 0-.813-.814L7.5 6.687 4.032 3.218a.575.575 0 0 0-.814.814L6.687 7.5l-3.469 3.468a.575.575 0 0 0 .814.814L7.5 8.313l3.469 3.469a.575.575 0 0 0 .813-.814L8.313 7.5l3.469-3.468Z"
+        fill="currentColor"
+      />
+    </svg>
+  );
+}

--- a/apps/frontend/src/app/rooms/_components/RoomJoinModal.tsx
+++ b/apps/frontend/src/app/rooms/_components/RoomJoinModal.tsx
@@ -1,0 +1,107 @@
+'use client';
+
+import { useState, useTransition, FormEvent } from 'react';
+import { Room } from '../../../types/room';
+import { joinRoom } from '../../../lib/api/rooms';
+
+interface RoomJoinModalProps {
+  backendToken: string;
+  onJoined: (room: Room) => void;
+  onClose: () => void;
+}
+
+export function RoomJoinModal({ backendToken, onJoined, onClose }: RoomJoinModalProps) {
+  const [inviteCode, setInviteCode] = useState('');
+  const [error, setError] = useState('');
+  const [isPending, startTransition] = useTransition();
+
+  const handleSubmit = (e: FormEvent<HTMLFormElement>) => {
+    e.preventDefault();
+    if (!inviteCode.trim()) return;
+
+    startTransition(async () => {
+      setError('');
+      try {
+        const room = await joinRoom(inviteCode.trim(), backendToken);
+        onJoined(room);
+      } catch (err) {
+        setError(err instanceof Error ? err.message : 'ルームへの参加に失敗しました');
+      }
+    });
+  };
+
+  return (
+    <div
+      className="fixed inset-0 z-50 flex items-start justify-center overflow-y-auto bg-black/40 p-4 py-10 backdrop-blur-sm"
+      onClick={(e) => { if (e.target === e.currentTarget) onClose(); }}
+    >
+      <div className="w-full max-w-md">
+        <div className="mb-4 flex items-center justify-between">
+          <h3 className="text-base font-semibold text-white">ルームに参加</h3>
+          <button
+            onClick={onClose}
+            className="rounded-lg p-1.5 text-zinc-300 transition-colors hover:bg-white/10 hover:text-white"
+            aria-label="閉じる"
+          >
+            <CloseIcon />
+          </button>
+        </div>
+
+        <div className="rounded-2xl bg-white p-6 shadow-sm dark:bg-zinc-900">
+          <form onSubmit={handleSubmit} className="space-y-4">
+            <div>
+              <label
+                htmlFor="invite-code"
+                className="mb-1.5 block text-sm font-medium text-zinc-700 dark:text-zinc-300"
+              >
+                招待コード
+              </label>
+              <input
+                id="invite-code"
+                type="text"
+                value={inviteCode}
+                onChange={(e) => setInviteCode(e.target.value)}
+                placeholder="招待コードを入力"
+                disabled={isPending}
+                className="w-full rounded-lg border border-zinc-200 bg-white px-3 py-2 text-sm text-zinc-900 placeholder-zinc-400 outline-none transition-colors focus:border-zinc-400 disabled:opacity-50 dark:border-zinc-700 dark:bg-zinc-800 dark:text-zinc-50 dark:placeholder-zinc-600 dark:focus:border-zinc-500"
+              />
+            </div>
+
+            {error && (
+              <p className="text-sm text-red-500">{error}</p>
+            )}
+
+            <div className="flex justify-end gap-2">
+              <button
+                type="button"
+                onClick={onClose}
+                disabled={isPending}
+                className="rounded-lg px-4 py-2 text-sm text-zinc-500 transition-colors hover:text-zinc-900 disabled:opacity-50 dark:text-zinc-400 dark:hover:text-zinc-50"
+              >
+                キャンセル
+              </button>
+              <button
+                type="submit"
+                disabled={isPending || !inviteCode.trim()}
+                className="rounded-lg bg-zinc-900 px-4 py-2 text-sm font-medium text-white transition-colors hover:bg-zinc-700 disabled:opacity-50 dark:bg-zinc-50 dark:text-zinc-900 dark:hover:bg-zinc-200"
+              >
+                {isPending ? '参加中…' : '参加'}
+              </button>
+            </div>
+          </form>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+function CloseIcon() {
+  return (
+    <svg width="15" height="15" viewBox="0 0 15 15" fill="none" xmlns="http://www.w3.org/2000/svg">
+      <path
+        d="M11.782 4.032a.575.575 0 1 0-.813-.814L7.5 6.687 4.032 3.218a.575.575 0 0 0-.814.814L6.687 7.5l-3.469 3.468a.575.575 0 0 0 .814.814L7.5 8.313l3.469 3.469a.575.575 0 0 0 .813-.814L8.313 7.5l3.469-3.468Z"
+        fill="currentColor"
+      />
+    </svg>
+  );
+}

--- a/apps/frontend/src/app/rooms/_components/RoomList.tsx
+++ b/apps/frontend/src/app/rooms/_components/RoomList.tsx
@@ -14,7 +14,7 @@ interface RoomListProps {
 type ModalState = 'none' | 'create' | 'join';
 
 export function RoomList({ rooms: initial, backendToken }: RoomListProps) {
-  const [rooms, setRooms] = useState(initial);
+  const [rooms, setRooms] = useState<Room[]>(initial);
   const [modalState, setModalState] = useState<ModalState>('none');
 
   const handleCreated = (room: Room) => {

--- a/apps/frontend/src/app/rooms/_components/RoomList.tsx
+++ b/apps/frontend/src/app/rooms/_components/RoomList.tsx
@@ -1,0 +1,88 @@
+'use client';
+
+import { useState } from 'react';
+import { Room } from '../../../types/room';
+import { RoomCard } from './RoomCard';
+import { RoomCreateModal } from './RoomCreateModal';
+import { RoomJoinModal } from './RoomJoinModal';
+
+interface RoomListProps {
+  rooms: Room[];
+  backendToken: string;
+}
+
+type ModalState = 'none' | 'create' | 'join';
+
+export function RoomList({ rooms: initial, backendToken }: RoomListProps) {
+  const [rooms, setRooms] = useState(initial);
+  const [modalState, setModalState] = useState<ModalState>('none');
+
+  const handleCreated = (room: Room) => {
+    setRooms((prev) => [room, ...prev]);
+    setModalState('none');
+  };
+
+  const handleJoined = (room: Room) => {
+    // 既に参加済みのルームが返ってくる場合を考慮して重複排除
+    setRooms((prev) =>
+      prev.some((r) => r.id === room.id) ? prev : [room, ...prev],
+    );
+    setModalState('none');
+  };
+
+  return (
+    <>
+      <div className="rounded-2xl bg-white shadow-sm dark:bg-zinc-900">
+        <div className="flex items-center justify-between border-b border-zinc-100 px-4 py-4 sm:px-8 sm:py-5 dark:border-zinc-800">
+          <h2 className="text-lg font-semibold text-zinc-900 dark:text-zinc-50">
+            ルーム一覧
+          </h2>
+          <div className="flex items-center gap-2">
+            <button
+              onClick={() => setModalState('join')}
+              className="rounded-lg px-3 py-1.5 text-sm text-zinc-500 transition-colors hover:bg-zinc-100 hover:text-zinc-900 dark:text-zinc-400 dark:hover:bg-zinc-800 dark:hover:text-zinc-50"
+            >
+              ルームに参加
+            </button>
+            <button
+              onClick={() => setModalState('create')}
+              className="rounded-lg bg-zinc-900 px-3 py-1.5 text-sm font-medium text-white transition-colors hover:bg-zinc-700 dark:bg-zinc-50 dark:text-zinc-900 dark:hover:bg-zinc-200"
+            >
+              ルームを作成
+            </button>
+          </div>
+        </div>
+
+        {rooms.length === 0 ? (
+          <div className="px-8 py-12 text-center">
+            <p className="text-sm text-zinc-400 dark:text-zinc-600">
+              ルームがありません
+            </p>
+          </div>
+        ) : (
+          <ul>
+            {rooms.map((room) => (
+              <RoomCard key={room.id} room={room} />
+            ))}
+          </ul>
+        )}
+      </div>
+
+      {modalState === 'create' && (
+        <RoomCreateModal
+          backendToken={backendToken}
+          onCreated={handleCreated}
+          onClose={() => setModalState('none')}
+        />
+      )}
+
+      {modalState === 'join' && (
+        <RoomJoinModal
+          backendToken={backendToken}
+          onJoined={handleJoined}
+          onClose={() => setModalState('none')}
+        />
+      )}
+    </>
+  );
+}

--- a/apps/frontend/src/app/rooms/page.tsx
+++ b/apps/frontend/src/app/rooms/page.tsx
@@ -1,0 +1,30 @@
+import { auth } from '../../../auth';
+import { redirect } from 'next/navigation';
+import { AppHeader } from '../../components/AppHeader';
+import { getRooms } from '../../lib/api/rooms';
+import { Room } from '../../types/room';
+import { RoomList } from './_components/RoomList';
+
+export default async function RoomsPage() {
+  const session = await auth();
+
+  if (!session) {
+    redirect('/');
+  }
+
+  let rooms: Room[] = [];
+  try {
+    rooms = await getRooms(session.backendToken);
+  } catch {
+    // 取得失敗時は空配列のまま
+  }
+
+  return (
+    <div className="min-h-screen bg-zinc-50 dark:bg-black">
+      <AppHeader currentPath="/rooms" />
+      <main className="mx-auto max-w-4xl space-y-6 px-4 py-6">
+        <RoomList rooms={rooms} backendToken={session.backendToken} />
+      </main>
+    </div>
+  );
+}

--- a/apps/frontend/src/components/AppHeader.tsx
+++ b/apps/frontend/src/components/AppHeader.tsx
@@ -49,6 +49,16 @@ export function AppHeader({ currentPath }: AppHeaderProps) {
               >
                 チャット
               </Link>
+              <Link
+                href="/rooms"
+                className={`text-sm transition-colors ${
+                  currentPath === '/rooms'
+                    ? 'text-zinc-900 dark:text-zinc-50'
+                    : 'text-zinc-500 hover:text-zinc-900 dark:text-zinc-400 dark:hover:text-zinc-50'
+                }`}
+              >
+                ルーム
+              </Link>
             </nav>
           </div>
           <form

--- a/apps/frontend/src/lib/api/receipts.ts
+++ b/apps/frontend/src/lib/api/receipts.ts
@@ -143,9 +143,14 @@ export async function getReceiptImagePresignedUrl(id: string, token: string): Pr
 export async function uploadReceipt(
   file: File,
   token: string,
+  roomId?: string,
 ): Promise<UploadReceiptResponse> {
   const formData = new FormData();
   formData.append('file', file);
+  // ルームへの投稿時のみroomIdを付与し、個人レシートとして区別する
+  if (roomId) {
+    formData.append('roomId', roomId);
+  }
 
   const res = await fetch(`${backendUrl}/receipts/upload`, {
     method: 'POST',

--- a/apps/frontend/src/lib/api/rooms.ts
+++ b/apps/frontend/src/lib/api/rooms.ts
@@ -1,0 +1,109 @@
+import { Room, RoomDetail, RoomReceiptItem } from '../../types/room';
+
+// SSR: BACKEND_URL（サーバー側env var）でバックエンドに直接通信
+// クライアント: /api/v1 の相対パス（本番はALBが転送、ローカルはNext.js rewriteがプロキシ）
+const backendUrl =
+  typeof window === 'undefined' ? process.env.BACKEND_URL : '/api/v1';
+
+export async function createRoom(name: string, token: string): Promise<Room> {
+  const res = await fetch(`${backendUrl}/rooms`, {
+    method: 'POST',
+    headers: {
+      Authorization: `Bearer ${token}`,
+      'Content-Type': 'application/json',
+    },
+    body: JSON.stringify({ name }),
+  });
+
+  if (!res.ok) {
+    const text = await res.text();
+    throw new Error(`ルームの作成に失敗しました (${res.status}): ${text}`);
+  }
+
+  return res.json() as Promise<Room>;
+}
+
+export async function getRooms(token: string): Promise<Room[]> {
+  const res = await fetch(`${backendUrl}/rooms`, {
+    headers: { Authorization: `Bearer ${token}` },
+  });
+
+  if (!res.ok) {
+    const text = await res.text();
+    throw new Error(`ルーム一覧の取得に失敗しました (${res.status}): ${text}`);
+  }
+
+  return res.json() as Promise<Room[]>;
+}
+
+export async function getRoom(id: string, token: string): Promise<RoomDetail> {
+  const res = await fetch(`${backendUrl}/rooms/${id}`, {
+    headers: { Authorization: `Bearer ${token}` },
+  });
+
+  if (!res.ok) {
+    const text = await res.text();
+    throw new Error(`ルームの取得に失敗しました (${res.status}): ${text}`);
+  }
+
+  return res.json() as Promise<RoomDetail>;
+}
+
+export async function joinRoom(inviteCode: string, token: string): Promise<Room> {
+  const res = await fetch(`${backendUrl}/rooms/join`, {
+    method: 'POST',
+    headers: {
+      Authorization: `Bearer ${token}`,
+      'Content-Type': 'application/json',
+    },
+    body: JSON.stringify({ inviteCode }),
+  });
+
+  if (!res.ok) {
+    const text = await res.text();
+    throw new Error(`ルームへの参加に失敗しました (${res.status}): ${text}`);
+  }
+
+  return res.json() as Promise<Room>;
+}
+
+export async function leaveRoom(id: string, token: string): Promise<void> {
+  const res = await fetch(`${backendUrl}/rooms/${id}/members/me`, {
+    method: 'DELETE',
+    headers: { Authorization: `Bearer ${token}` },
+  });
+
+  if (!res.ok) {
+    const text = await res.text();
+    throw new Error(`ルームからの退出に失敗しました (${res.status}): ${text}`);
+  }
+}
+
+export async function deleteRoom(id: string, token: string): Promise<void> {
+  const res = await fetch(`${backendUrl}/rooms/${id}`, {
+    method: 'DELETE',
+    headers: { Authorization: `Bearer ${token}` },
+  });
+
+  if (!res.ok) {
+    const text = await res.text();
+    throw new Error(`ルームの削除に失敗しました (${res.status}): ${text}`);
+  }
+}
+
+export async function listRoomReceipts(
+  roomId: string,
+  token: string,
+): Promise<RoomReceiptItem[]> {
+  const res = await fetch(`${backendUrl}/rooms/${roomId}/receipts`, {
+    headers: { Authorization: `Bearer ${token}` },
+  });
+
+  if (!res.ok) {
+    const text = await res.text();
+    throw new Error(`ルームのレシート一覧取得に失敗しました (${res.status}): ${text}`);
+  }
+
+  const data = (await res.json()) as { items: RoomReceiptItem[] };
+  return data.items;
+}

--- a/apps/frontend/src/types/room.ts
+++ b/apps/frontend/src/types/room.ts
@@ -1,0 +1,42 @@
+import { ReceiptStatus } from './receipt';
+
+export type RoomMemberRole = 'owner' | 'member';
+
+export interface RoomMember {
+  id: string;
+  userId: string;
+  displayName: string | null;
+  avatarUrl: string | null;
+  role: RoomMemberRole;
+  joinedAt: string;
+}
+
+export interface Room {
+  id: string;
+  name: string;
+  ownerId: string;
+  memberCount: number;
+  createdAt: string;
+}
+
+export interface RoomDetail {
+  id: string;
+  name: string;
+  ownerId: string;
+  inviteCode: string | null;
+  members: RoomMember[];
+  createdAt: string;
+}
+
+export interface RoomReceiptItem {
+  id: string;
+  userId: string;
+  uploaderDisplayName: string | null;
+  status: ReceiptStatus;
+  originalFileName: string;
+  storeName: string | null;
+  purchasedAt: string | null;
+  total: number | null;
+  currency: string | null;
+  createdAt: string;
+}


### PR DESCRIPTION
## Summary

Room機能（Issue #92〜#98）をまとめて実装しました。

### Backend
- **#92** DBスキーマ: `rooms`・`room_members` テーブル追加、`receipts` に `room_id` カラム追加、TypeORMマイグレーション
- **#93** ルーム管理API: ルーム作成・一覧・詳細・解散・退出エンドポイント（`/rooms`）
- **#94** 招待コードAPI: 招待コードによるルーム参加・招待コード再生成エンドポイント
- **#95** レシートAPIのルーム対応: アップロード時の `roomId` 受け付け、ルーム別レシート一覧（`GET /rooms/:id/receipts`）、サマリAPIへの `roomId` フィルター追加

### Frontend
- **#96** ルーム作成・参加UI: `/rooms` ページ、RoomCard・RoomCreateModal・RoomJoinModal コンポーネント、rooms APIクライアント、AppHeaderにルームリンク追加
- **#97** ルーム切り替えUI: `/receipts` にタブ切り替え（個人/ルーム）、URLクエリパラメータ `?roomId` で状態管理、ルームレシートのアップローダー名表示
- **#98** アップロード時のルーム選択: ReceiptUploadCard にルーム選択セレクタ追加

## Test plan

- [ ] `npm run migration:run` でマイグレーションが正常に完了すること
- [ ] `POST /rooms` でルームが作成され、`room_members` に `owner` ロールで登録されること
- [ ] `POST /rooms/join` で招待コードによる参加ができ、既存メンバーは 409 になること
- [ ] `GET /rooms/:id` でオーナーのみ `inviteCode` が返ること
- [ ] `DELETE /rooms/:id` でオーナーのみ解散でき、非オーナーは 403 になること
- [ ] `POST /receipts/upload` に `roomId` を付与するとレシートのルームが設定されること
- [ ] `GET /rooms/:id/receipts` でルームメンバー全員のレシートが返ること
- [ ] `/rooms` ページでルームの作成・参加ができること
- [ ] `/receipts` でルームタブ切り替えができ、ルーム選択時はそのルームのレシートが表示されること
- [ ] アップロード時にルームを選択すると、そのルームにレシートが紐づくこと

🤖 Generated with [Claude Code](https://claude.com/claude-code)