### PR TITLE
fix: マイグレーター用DataSourceにRoom・RoomMemberエンティティを追加 #92

### DIFF
--- a/apps/backend/src/database/data-source.ts
+++ b/apps/backend/src/database/data-source.ts
@@ -4,11 +4,13 @@ import { Receipt } from '../entities/receipt.entity';
 import { ReceiptItem } from '../entities/receipt-item.entity';
 import { ChatSession } from '../entities/chat-session.entity';
 import { ChatMessage } from '../entities/chat-message.entity';
+import { Room } from '../entities/room.entity';
+import { RoomMember } from '../entities/room-member.entity';
 
 export const AppDataSource = new DataSource({
   type: 'postgres',
   url: process.env.DATABASE_URL,
-  entities: [User, Receipt, ReceiptItem, ChatSession, ChatMessage],
+  entities: [User, Receipt, ReceiptItem, ChatSession, ChatMessage, Room, RoomMember],
   migrations: ['dist/migrations/*.js'],
   synchronize: false,
   logging: process.env.TYPEORM_LOGGING === 'true',


### PR DESCRIPTION
## Summary

PR #158のマージ後にマイグレーションが失敗した問題を修正します。

- `apps/backend/src/database/data-source.ts` — マイグレーター専用の DataSource に `Room`・`RoomMember` エンティティを追加

**原因**: `app.module.ts` とは別に `data-source.ts`（マイグレーター/TypeORM CLI 用）が存在しており、こちらへの追加が漏れていた。マイグレーション実行時に `Receipt#room` のリレーション解決でエラーが発生していた。

```
TypeORMError: Entity metadata for Receipt#room was not found.
Check if you specified a correct entity object and if it's connected in the connection options.
```

## Test plan

- [ ] マイグレーションが正常に完了すること
- [ ] `rooms`・`room_members` テーブルが作成され、`receipts` に `room_id` カラムが追加されること

🤖 Generated with [Claude Code](https://claude.com/claude-code)