### PR TITLE
fix: AUTH_URLにapi/authパスを追加してredirect_uri_mismatchを修正

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -11,7 +11,7 @@ S3_BUCKET_NAME=credit-checker-dev
 FRONTEND_URL=http://localhost:3000
 BACKEND_URL=http://backend:3003/api/v1
 NEXT_PUBLIC_BACKEND_URL=http://localhost:3003/api/v1
-AUTH_URL=http://localhost:3000/credit-checker
+AUTH_URL=http://localhost:3000/credit-checker/api/auth
 AUTH_GOOGLE_ID=
 
 # Postgres（docker compose でのみ使用）

--- a/infra/lib/app/app-stack.ts
+++ b/infra/lib/app/app-stack.ts
@@ -137,7 +137,7 @@ export class AppStack extends cdk.Stack {
         AUTH_GOOGLE_ID: config.authGoogleId,
         BACKEND_URL: `https://${config.domain}/api/v1`,
         NEXT_PUBLIC_BACKEND_URL: `https://${config.domain}/api/v1`,
-        AUTH_URL: `https://${config.domain}/credit-checker`,
+        AUTH_URL: `https://${config.domain}/credit-checker/api/auth`,
       },
       secrets: {
         AUTH_SECRET: ecs.Secret.fromSecretsManager(authSecret),


### PR DESCRIPTION
## 変更内容

Auth.js v5の仕様に合わせて`AUTH_URL`を修正。

Auth.js v5は`{AUTH_URL}/callback/{provider}`をredirect_uriとして使用するため、`AUTH_URL`にはauth routeのベースパス（`/api/auth`）まで含める必要がある。

## 変更ファイル

- `infra/lib/app/app-stack.ts`: `AUTH_URL` を `https://${domain}/credit-checker` → `https://${domain}/credit-checker/api/auth` に変更
- `.env.example`: `AUTH_URL` を `http://localhost:3000/credit-checker` → `http://localhost:3000/credit-checker/api/auth` に変更

## テスト計画

- [ ] ローカル環境でGoogle OAuthのredirect_uriが`http://localhost:3000/credit-checker/api/auth/callback/google`になっていることを確認
- [ ] Google Cloud ConsoleのOAuth設定に上記URIが登録されていることを確認
- [ ] 本番環境でのOAuth認証フローが正常に動作することを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)