### PR TITLE
fix: Auth.jsのbasePath明示指定でUnknownActionエラーを修正

### DIFF
--- a/apps/frontend/auth.ts
+++ b/apps/frontend/auth.ts
@@ -14,6 +14,7 @@ declare module '@auth/core/jwt' {
 }
 
 export const { handlers, auth, signIn, signOut } = NextAuth({
+  basePath: '/api/auth',
   providers: [Google],
   callbacks: {
     async jwt({ token, account, profile }) {


### PR DESCRIPTION
## Summary

- `auth.ts` の `NextAuth()` に `basePath: '/api/auth'` を明示指定
- Auth.js v5 は `AUTH_URL.pathname` でアクション解析するが、Next.js がbasePath（`/credit-checker`）を剥ぎ取るため内部パスが `/api/auth/callback/google` になり `AUTH_URL.pathname = /credit-checker/api/auth` とマッチせず "UnknownAction" エラーが発生していた
- `basePath` を明示指定することで内部パスからの正しいアクション解析を実現する

## 関連
- #160 （AUTH_URL修正、マージ済み）

## Test plan
- [ ] ログインボタンを押してGoogleログインが完了すること
- [ ] コールバック後 `/dashboard` にリダイレクトされること

🤖 Generated with [Claude Code](https://claude.com/claude-code)