### PR TITLE
fix: Next.js 16のasync paramsに対応しAuth.jsのOAuthコールバックを修正

### DIFF
--- a/apps/frontend/auth.ts
+++ b/apps/frontend/auth.ts
@@ -14,7 +14,6 @@ declare module '@auth/core/jwt' {
 }
 
 export const { handlers, auth, signIn, signOut } = NextAuth({
-  basePath: '/api/auth',
   providers: [Google],
   callbacks: {
     async jwt({ token, account, profile }) {

--- a/apps/frontend/src/app/api/auth/[...nextauth]/route.ts
+++ b/apps/frontend/src/app/api/auth/[...nextauth]/route.ts
@@ -1,3 +1,20 @@
 import { handlers } from '../../../../../auth';
+import { type NextRequest } from 'next/server';
 
-export const { GET, POST } = handlers;
+// Next.js 15+ で params が Promise になったため、await して Auth.js に渡す
+// Auth.js v5 beta が古い同期形式を期待している場合でも正しくパラムを渡せるようにする
+export async function GET(
+  request: NextRequest,
+  context: { params: Promise<{ nextauth: string[] }> },
+) {
+  const params = await context.params;
+  return handlers.GET(request, { params });
+}
+
+export async function POST(
+  request: NextRequest,
+  context: { params: Promise<{ nextauth: string[] }> },
+) {
+  const params = await context.params;
+  return handlers.POST(request, { params });
+}


### PR DESCRIPTION
## Summary

- `auth.ts` から誤って追加した `basePath: '/api/auth'` を削除（redirect_uriの生成式が変わり `/credit-checker` が消える問題を修正）
- `route.ts` で Next.js 15+ の async params に対応し、Auth.js に正しくパラムを渡すよう修正

## 背景

Next.js 15以降、route handlerの `params` が `Promise` になった。Auth.js v5 beta.30 は旧来の同期形式を期待しているため、`params` が Promise のままだとアクション解析に失敗し URL パースにフォールバックしていた。URL パースでは `AUTH_URL.pathname = /credit-checker/api/auth` と内部パス `/api/auth/callback/google`（Next.jsがbasePath除去済み）が一致せず "UnknownAction" エラーが発生していた。

## 関連
- #160（AUTH_URL修正）
- #169（basePath追加、本PRで削除）

## Test plan
- [ ] ログインボタンを押してGoogle認証が完了すること
- [ ] コールバック後 `/dashboard` にリダイレクトされること

🤖 Generated with [Claude Code](https://claude.com/claude-code)