### PR TITLE
fix: Auth.js route handlerのbasePath補完によるUnknownActionを修正 #160

### DIFF
--- a/apps/frontend/src/app/api/auth/[...nextauth]/route.ts
+++ b/apps/frontend/src/app/api/auth/[...nextauth]/route.ts
@@ -1,20 +1,28 @@
 import { handlers } from '../../../../../auth';
 import { type NextRequest } from 'next/server';
 
-// Next.js 15+ で params が Promise になったため、await して Auth.js に渡す
-// Auth.js v5 beta が古い同期形式を期待している場合でも正しくパラムを渡せるようにする
-export async function GET(
-  request: NextRequest,
-  context: { params: Promise<{ nextauth: string[] }> },
-) {
-  const params = await context.params;
-  return handlers.GET(request, { params });
+// Next.js はbasePath(/credit-checker)をrequest.urlから除去するため、
+// AUTH_URL.pathnameとのマッチに失敗しAuth.jsがUnknownActionエラーを起こす。
+// リクエストURLにbasePath相当のパスを補完することで正しくアクション解析させる。
+function restoreBasePath(request: NextRequest): Request {
+  const authUrl = process.env.AUTH_URL;
+  if (!authUrl) return request;
+
+  const basePath = new URL(authUrl).pathname.replace(/\/api\/auth$/, '');
+  if (!basePath) return request;
+
+  const url = new URL(request.url);
+  if (!url.pathname.startsWith(basePath)) {
+    url.pathname = basePath + url.pathname;
+    return new Request(url.toString(), request);
+  }
+  return request;
 }
 
-export async function POST(
-  request: NextRequest,
-  context: { params: Promise<{ nextauth: string[] }> },
-) {
-  const params = await context.params;
-  return handlers.POST(request, { params });
+export async function GET(request: NextRequest) {
+  return handlers.GET(restoreBasePath(request));
+}
+
+export async function POST(request: NextRequest) {
+  return handlers.POST(restoreBasePath(request));
 }


### PR DESCRIPTION
## Summary

- Next.jsの`basePath`(`/credit-checker`)がinternal request URLから除去されることで、Auth.jsがアクション解析に失敗する問題を修正
- `handlers.GET`に2引数を渡していたことによるDockerビルドエラーも合わせて修正
- `restoreBasePath()`関数でリクエストURLに`basePath`を補完してからAuth.jsに渡す方式に変更

## 変更内容

`apps/frontend/src/app/api/auth/[...nextauth]/route.ts`
- `handlers.GET(request, { params })`（2引数）→ `handlers.GET(restoreBasePath(request))`（1引数）に変更
- `AUTH_URL`の`pathname`から`/api/auth`を除いた部分をbasePath相当として取得し、requestのURLに補完する`restoreBasePath()`を実装

## 技術背景

- Next.jsは`basePath`をinternal request URLから除去するため、Auth.jsが`AUTH_URL.pathname`とのマッチに失敗し`UnknownAction`エラーが発生する
- `AUTH_URL = https://.../credit-checker/api/auth`のとき、internal pathは`/api/auth/callback/google`になる
- `restoreBasePath()`が`/credit-checker`を補完することで`/credit-checker/api/auth/callback/google`となり正しく解析される

## Test plan

- [ ] ローカルでOAuthログインが成功することを確認
- [ ] devデプロイ後に`https://dev.jun-eg.site/credit-checker`でGoogleログインが成功することを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)