### PR TITLE
fix: restoreBasePathの戻り値をNextRequestに修正 #160

### DIFF
--- a/apps/frontend/src/app/api/auth/[...nextauth]/route.ts
+++ b/apps/frontend/src/app/api/auth/[...nextauth]/route.ts
@@ -1,10 +1,10 @@
 import { handlers } from '../../../../../auth';
-import { type NextRequest } from 'next/server';
+import { NextRequest } from 'next/server';
 
 // Next.js はbasePath(/credit-checker)をrequest.urlから除去するため、
 // AUTH_URL.pathnameとのマッチに失敗しAuth.jsがUnknownActionエラーを起こす。
 // リクエストURLにbasePath相当のパスを補完することで正しくアクション解析させる。
-function restoreBasePath(request: NextRequest): Request {
+function restoreBasePath(request: NextRequest): NextRequest {
   const authUrl = process.env.AUTH_URL;
   if (!authUrl) return request;
 
@@ -14,7 +14,7 @@ function restoreBasePath(request: NextRequest): Request {
   const url = new URL(request.url);
   if (!url.pathname.startsWith(basePath)) {
     url.pathname = basePath + url.pathname;
-    return new Request(url.toString(), request);
+    return new NextRequest(url.toString(), request);
   }
   return request;
 }


### PR DESCRIPTION
## Summary

- `restoreBasePath()`の戻り値型を`Request`から`NextRequest`に変更
- `new Request(...)`を`new NextRequest(...)`に変更
- `import { type NextRequest }`を`import { NextRequest }`に変更（値としても使用するため）

## 背景

PR #171でDockerbuildが型エラーで失敗:
```
Type error: Argument of type 'Request' is not assignable to parameter of type 'NextRequest'.
  Type 'Request' is missing the following properties from type 'NextRequest': cookies, nextUrl, page, ua
```

`handlers.GET`は`NextRequest`を期待しているが、`new Request(...)`は標準Web APIの`Request`を返すため型不一致が発生していた。

## Test plan

- [ ] Dockerビルドが成功することを確認
- [ ] devデプロイ後にGoogleログインが成功することを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)