### PR TITLE
fix: Auth.jsのredirectToにbasePathを補完してリダイレクト先404を修正

### DIFF
--- a/apps/frontend/src/app/page.tsx
+++ b/apps/frontend/src/app/page.tsx
@@ -11,7 +11,7 @@ export default async function Home() {
 
   const handleSignIn = async () => {
     'use server';
-    await signIn('google', { redirectTo: '/dashboard' });
+    await signIn('google', { redirectTo: '/credit-checker/dashboard' });
   };
 
   return (

--- a/apps/frontend/src/components/AppHeader.tsx
+++ b/apps/frontend/src/components/AppHeader.tsx
@@ -64,7 +64,7 @@ export function AppHeader({ currentPath }: AppHeaderProps) {
           <form
             action={async () => {
               'use server';
-              await signOut({ redirectTo: '/' });
+              await signOut({ redirectTo: '/credit-checker/' });
             }}
           >
             <button


### PR DESCRIPTION
## 原因

`next.config.ts` の `basePath: '/credit-checker'` により、アプリは `/credit-checker/*` 配下で動作している。

`next/navigation` の `redirect()` は Next.js がbasePathを自動補完するが、Auth.js の `signIn` / `signOut` の `redirectTo` は Auth.js が直接 HTTP リダイレクトを発行するため、basePath が補完されない。

その結果、ログイン後に `https://dev.jun-eg.site/dashboard`（basePath なし）へリダイレクトされ 404 になっていた。

## 修正内容

- `src/app/page.tsx`: `signIn` の `redirectTo: '/dashboard'` → `'/credit-checker/dashboard'`
- `src/components/AppHeader.tsx`: `signOut` の `redirectTo: '/'` → `'/credit-checker/'`

## Test plan

- [ ] ログインボタン押下後、`https://dev.jun-eg.site/credit-checker/dashboard` にリダイレクトされること
- [ ] ログアウトボタン押下後、`https://dev.jun-eg.site/credit-checker/` にリダイレクトされること

🤖 Generated with [Claude Code](https://claude.com/claude-code)