### PR TITLE
fix: middlewareのリダイレクトにbasePathが付与されない問題を修正 #178

### DIFF
--- a/apps/frontend/middleware.ts
+++ b/apps/frontend/middleware.ts
@@ -6,20 +6,27 @@ const PUBLIC_PATHS = ['/', '/select'];
 export default auth((req) => {
   const { pathname } = req.nextUrl;
 
+  // new URL() は basePath を付与しないため nextUrl.clone() で basePath を保持する
+  const redirect = (path: string) => {
+    const url = req.nextUrl.clone();
+    url.pathname = path;
+    return NextResponse.redirect(url);
+  };
+
   // 未認証: ログインページ以外はトップへ
   if (!req.auth && pathname !== '/') {
-    return NextResponse.redirect(new URL('/', req.nextUrl));
+    return redirect('/');
   }
 
   // 認証済みでログインページ → select へ
   if (req.auth && pathname === '/') {
-    return NextResponse.redirect(new URL('/select', req.nextUrl));
+    return redirect('/select');
   }
 
   // 認証済み・モード未選択・保護ページ → select へ
   const modeCookie = req.cookies.get('app-mode');
   if (req.auth && !PUBLIC_PATHS.includes(pathname) && !modeCookie?.value) {
-    return NextResponse.redirect(new URL('/select', req.nextUrl));
+    return redirect('/select');
   }
 });
 


### PR DESCRIPTION
## Summary
- middleware.ts の `new URL('/select', req.nextUrl)` が標準 `URL` コンストラクタのため `basePath: '/credit-checker'` を付与せず、`/select` にリダイレクトされて 404 になっていた
- `req.nextUrl.clone()` + `pathname` 書き換えに変更し、`NextURL` が basePath を自動付与するように修正

## Test plan
- [ ] 認証済みで `/credit-checker/` にアクセス → `/credit-checker/select` にリダイレクトされること（`/select` ではない）
- [ ] 未認証で `/credit-checker/dashboard` にアクセス → `/credit-checker/` にリダイレクトされること
- [ ] 認証済み・モード未選択で `/credit-checker/dashboard` にアクセス → `/credit-checker/select` にリダイレクトされること

Closes #178

🤖 Generated with [Claude Code](https://claude.com/claude-code)