### PR TITLE
fix: middlewareリダイレクトでbasePathが付与されない問題を修正 #180

### DIFF
--- a/apps/frontend/middleware.ts
+++ b/apps/frontend/middleware.ts
@@ -6,12 +6,9 @@ const PUBLIC_PATHS = ['/', '/select'];
 export default auth((req) => {
   const { pathname } = req.nextUrl;
 
-  // new URL() は basePath を付与しないため nextUrl.clone() で basePath を保持する
-  const redirect = (path: string) => {
-    const url = req.nextUrl.clone();
-    url.pathname = path;
-    return NextResponse.redirect(url);
-  };
+  // NextURL.clone() 経由でも adapter が basePath を落とすため、直接 basePath を付与する
+  const redirect = (path: string) =>
+    NextResponse.redirect(new URL(`${req.nextUrl.basePath}${path}`, req.url));
 
   // 未認証: ログインページ以外はトップへ
   if (!req.auth && pathname !== '/') {


### PR DESCRIPTION
## Summary
- middleware の `NextResponse.redirect()` で `NextURL.clone()` + `pathname` 設定を使っていたが、Next.js の middleware adapter が Location ヘッダーを再処理する際に basePath が消失していた
- `req.nextUrl.basePath` をパスに直接結合して標準 `URL` を構築する方式に変更し、adapter の影響を受けない形でリダイレクト URL を生成するように修正

## 変更内容

```diff
- const redirect = (path: string) => {
-   const url = req.nextUrl.clone();
-   url.pathname = path;
-   return NextResponse.redirect(url);
- };
+ const redirect = (path: string) =>
+   NextResponse.redirect(new URL(`${req.nextUrl.basePath}${path}`, req.url));
```

## Test plan
- [ ] 未認証で `/credit-checker/select` にアクセス → `/credit-checker/` にリダイレクト（`/` ではない）
- [ ] 認証済みで `/credit-checker/` にアクセス → `/credit-checker/select` にリダイレクト（`/select` ではない）
- [ ] 認証済み・モード未選択で `/credit-checker/dashboard` にアクセス → `/credit-checker/select` にリダイレクト

Closes #180

🤖 Generated with [Claude Code](https://claude.com/claude-code)