### PR TITLE
fix: Auth.jsがnextConfigを落とすためbasePathをnext.configから直接読み込む #182

### DIFF
--- a/apps/frontend/middleware.ts
+++ b/apps/frontend/middleware.ts
@@ -1,14 +1,21 @@
 import { auth } from './auth';
 import { NextResponse } from 'next/server';
+import nextConfig from './next.config';
 
+// Auth.js の reqWithEnvURL が nextConfig を落とすため
+// req.nextUrl.basePath が空、pathname に basePath が残る場合がある。
+// next.config.ts から直接読み込んで両方を自前で処理する。
+const BASE_PATH = nextConfig.basePath ?? '';
 const PUBLIC_PATHS = ['/', '/select'];
 
 export default auth((req) => {
-  const { pathname } = req.nextUrl;
+  const raw = req.nextUrl.pathname;
+  const pathname = raw.startsWith(BASE_PATH)
+    ? raw.slice(BASE_PATH.length) || '/'
+    : raw;
 
-  // NextURL.clone() 経由でも adapter が basePath を落とすため、直接 basePath を付与する
   const redirect = (path: string) =>
-    NextResponse.redirect(new URL(`${req.nextUrl.basePath}${path}`, req.url));
+    NextResponse.redirect(new URL(`${BASE_PATH}${path}`, req.url));
 
   // 未認証: ログインページ以外はトップへ
   if (!req.auth && pathname !== '/') {


### PR DESCRIPTION
## Summary
- Auth.js v5 の `reqWithEnvURL()` が `new NextRequest(url, req)` でリクエストを再生成する際に `nextConfig` を渡さないため、middleware コールバック内で `req.nextUrl.basePath` が空文字、`req.nextUrl.pathname` に basePath が含まれたままになっていた
- `next.config.ts` から `basePath` を直接 import し、pathname の basePath 除去とリダイレクト URL 構築を自前で処理するように修正

## 原因の詳細

Auth.js `next-auth/lib/env.js` の `reqWithEnvURL()`:
```javascript
return new NextRequest(href.replace(origin, envOrigin), req);
```
`NextRequest` は `nextConfig` を内部シンボルに格納しており外部プロパティとして公開しないため、`req` を `init` として渡しても `nextConfig` が引き継がれない。

| プロパティ | 期待値 | 実際の値 |
|-----------|--------|---------|
| `req.nextUrl.pathname` | `/select` | `/credit-checker/select` |
| `req.nextUrl.basePath` | `/credit-checker` | `` (空) |

## Test plan
- [ ] 未認証で `/credit-checker/select` にアクセス → `/credit-checker/` にリダイレクト
- [ ] 認証済みで `/credit-checker/` にアクセス → `/credit-checker/select` にリダイレクト
- [ ] 認証済み・モード未選択で `/credit-checker/dashboard` にアクセス → `/credit-checker/select` にリダイレクト
- [ ] Google OAuth ログイン後 `/credit-checker/select` に正しく遷移すること

Closes #182

🤖 Generated with [Claude Code](https://claude.com/claude-code)