### PR TITLE
refactor: basePath撤廃してcredit-checkerサブドメインに移行 #184

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -11,7 +11,7 @@ S3_BUCKET_NAME=credit-checker-dev
 FRONTEND_URL=http://localhost:3000
 BACKEND_URL=http://backend:3003/api/v1
 NEXT_PUBLIC_BACKEND_URL=http://localhost:3003/api/v1
-AUTH_URL=http://localhost:3000/credit-checker/api/auth
+AUTH_URL=http://localhost:3000/api/auth
 AUTH_GOOGLE_ID=
 
 # Postgres（docker compose でのみ使用）

--- a/apps/frontend/middleware.ts
+++ b/apps/frontend/middleware.ts
@@ -6,24 +6,20 @@ const PUBLIC_PATHS = ['/', '/select'];
 export default auth((req) => {
   const { pathname } = req.nextUrl;
 
-  // NextURL.clone() 経由でも adapter が basePath を落とすため、直接 basePath を付与する
-  const redirect = (path: string) =>
-    NextResponse.redirect(new URL(`${req.nextUrl.basePath}${path}`, req.url));
-
   // 未認証: ログインページ以外はトップへ
   if (!req.auth && pathname !== '/') {
-    return redirect('/');
+    return NextResponse.redirect(new URL('/', req.url));
   }
 
   // 認証済みでログインページ → select へ
   if (req.auth && pathname === '/') {
-    return redirect('/select');
+    return NextResponse.redirect(new URL('/select', req.url));
   }
 
   // 認証済み・モード未選択・保護ページ → select へ
   const modeCookie = req.cookies.get('app-mode');
   if (req.auth && !PUBLIC_PATHS.includes(pathname) && !modeCookie?.value) {
-    return redirect('/select');
+    return NextResponse.redirect(new URL('/select', req.url));
   }
 });
 

--- a/apps/frontend/next.config.ts
+++ b/apps/frontend/next.config.ts
@@ -1,13 +1,12 @@
 import type { NextConfig } from 'next';
 
 const nextConfig: NextConfig = {
-  basePath: '/credit-checker',
   output: 'standalone',
   experimental: {
     // CloudFront → ALB 経由だと Host ヘッダーが ALB の DNS 名に書き換わり
     // Next.js の Server Action CSRF チェックが 403 を返すため許可ドメインを明示する
     serverActions: {
-      allowedOrigins: ['dev.jun-eg.site', 'jun-eg.site'],
+      allowedOrigins: ['credit-checker.dev.jun-eg.site', 'credit-checker.jun-eg.site'],
     },
   },
   async rewrites() {

--- a/apps/frontend/src/app/api/auth/[...nextauth]/route.ts
+++ b/apps/frontend/src/app/api/auth/[...nextauth]/route.ts
@@ -1,28 +1,3 @@
 import { handlers } from '../../../../../auth';
-import { NextRequest } from 'next/server';
 
-// Next.js はbasePath(/credit-checker)をrequest.urlから除去するため、
-// AUTH_URL.pathnameとのマッチに失敗しAuth.jsがUnknownActionエラーを起こす。
-// リクエストURLにbasePath相当のパスを補完することで正しくアクション解析させる。
-function restoreBasePath(request: NextRequest): NextRequest {
-  const authUrl = process.env.AUTH_URL;
-  if (!authUrl) return request;
-
-  const basePath = new URL(authUrl).pathname.replace(/\/api\/auth$/, '');
-  if (!basePath) return request;
-
-  const url = new URL(request.url);
-  if (!url.pathname.startsWith(basePath)) {
-    url.pathname = basePath + url.pathname;
-    return new NextRequest(url.toString(), request);
-  }
-  return request;
-}
-
-export async function GET(request: NextRequest) {
-  return handlers.GET(restoreBasePath(request));
-}
-
-export async function POST(request: NextRequest) {
-  return handlers.POST(restoreBasePath(request));
-}
+export const { GET, POST } = handlers;

--- a/apps/frontend/src/app/page.tsx
+++ b/apps/frontend/src/app/page.tsx
@@ -11,7 +11,7 @@ export default async function Home() {
 
   const handleSignIn = async () => {
     'use server';
-    await signIn('google', { redirectTo: '/credit-checker/select' });
+    await signIn('google', { redirectTo: '/select' });
   };
 
   return (

--- a/apps/frontend/src/components/AppHeader.tsx
+++ b/apps/frontend/src/components/AppHeader.tsx
@@ -57,7 +57,7 @@ export function AppHeader({ currentPath }: AppHeaderProps) {
             <form
               action={async () => {
                 'use server';
-                await signOut({ redirectTo: '/credit-checker/' });
+                await signOut({ redirectTo: '/' });
               }}
             >
               <button

--- a/apps/frontend/src/contexts/ModeContext.tsx
+++ b/apps/frontend/src/contexts/ModeContext.tsx
@@ -7,7 +7,7 @@ export type AppMode =
   | { type: 'room'; room: { id: string; name: string } };
 
 const COOKIE_NAME = 'app-mode';
-const COOKIE_PATH = '/credit-checker';
+const COOKIE_PATH = '/';
 
 function encodeMode(mode: AppMode): string {
   if (mode.type === 'personal') return 'personal';

--- a/infra/config/dev.ts
+++ b/infra/config/dev.ts
@@ -7,6 +7,7 @@ export const devConfig: EnvironmentConfig = {
     region: process.env.AWS_REGION!,
   },
   domain: 'dev.jun-eg.site',
+  frontendDomain: 'credit-checker.dev.jun-eg.site',
   scaling: {
     frontend: { minCapacity: 0, maxCapacity: 2 },
     backend: { minCapacity: 0, maxCapacity: 2 },

--- a/infra/config/index.ts
+++ b/infra/config/index.ts
@@ -5,6 +5,7 @@ export interface EnvironmentConfig {
     region: string;
   };
   domain: string;
+  frontendDomain: string;
   scaling: {
     frontend: { minCapacity: number; maxCapacity: number };
     backend: { minCapacity: number; maxCapacity: number };

--- a/infra/config/prod.ts
+++ b/infra/config/prod.ts
@@ -7,6 +7,7 @@ export const prodConfig: EnvironmentConfig = {
     region: process.env.AWS_REGION!,
   },
   domain: 'jun-eg.site',
+  frontendDomain: 'credit-checker.jun-eg.site',
   scaling: {
     frontend: { minCapacity: 1, maxCapacity: 3 },
     backend: { minCapacity: 1, maxCapacity: 3 },

--- a/infra/lib/app/app-stack.ts
+++ b/infra/lib/app/app-stack.ts
@@ -135,9 +135,9 @@ export class AppStack extends cdk.Stack {
         NODE_ENV: config.nodeEnv,
         FRONTEND_PORT: String(config.ports.frontend),
         AUTH_GOOGLE_ID: config.authGoogleId,
-        BACKEND_URL: `https://${config.domain}/api/v1`,
-        NEXT_PUBLIC_BACKEND_URL: `https://${config.domain}/api/v1`,
-        AUTH_URL: `https://${config.domain}/credit-checker/api/auth`,
+        BACKEND_URL: `https://${config.frontendDomain}/api/v1`,
+        NEXT_PUBLIC_BACKEND_URL: `https://${config.frontendDomain}/api/v1`,
+        AUTH_URL: `https://${config.frontendDomain}/api/auth`,
       },
       secrets: {
         AUTH_SECRET: ecs.Secret.fromSecretsManager(authSecret),
@@ -190,7 +190,7 @@ export class AppStack extends cdk.Stack {
         TYPEORM_LOGGING: String(config.typeormLogging),
         AWS_REGION: config.env.region,
         S3_BUCKET_NAME: appBucket.bucketName,
-        FRONTEND_URL: `https://${config.domain}`,
+        FRONTEND_URL: `https://${config.frontendDomain}`,
       },
       secrets: {
         JWT_SECRET: ecs.Secret.fromSecretsManager(jwtSecret),

--- a/infra/lib/edge/edge-stack.ts
+++ b/infra/lib/edge/edge-stack.ts
@@ -85,7 +85,7 @@ export class EdgeStack extends cdk.Stack {
       protocol: elbv2.ApplicationProtocol.HTTP,
       targets: [frontendService],
       healthCheck: {
-        path: '/credit-checker',
+        path: '/',
         interval: cdk.Duration.seconds(30),
       },
     });
@@ -108,14 +108,14 @@ export class EdgeStack extends cdk.Stack {
         // Next.js Server Action は POST を使用するため ALL を許可する
         allowedMethods: cloudfront.AllowedMethods.ALLOW_ALL,
       },
-      domainNames: [config.domain],
+      domainNames: [config.frontendDomain],
       certificate,
     });
 
     // Route53 A レコード → CloudFront
     new route53.ARecord(this, 'AliasRecord', {
       zone: hostedZone,
-      recordName: config.domain,
+      recordName: config.frontendDomain,
       target: route53.RecordTarget.fromAlias(
         new route53Targets.CloudFrontTarget(distribution),
       ),


### PR DESCRIPTION
## Summary
- Next.js の `basePath: '/credit-checker'` を撤廃し、アプリを `credit-checker.{dev.,}jun-eg.site` のサブドメインで配信する構成に変更
- これにより `/credit-checker` のハードコードがアプリコードから完全に消え、Auth.js v5 との相性問題（`reqWithEnvURL` が `nextConfig` を落とす #178, #180, #182）も根本解決

## 背景

`basePath` は本来 Next.js が透過的に扱うはずだが、Auth.js v5 が middleware のリクエストを再生成する際に `nextConfig` を落とすため、middleware 内で basePath 情報が失われる。この結果、`signIn`/`signOut`/Cookie/middleware/auth route handler の各所で `/credit-checker` を手動で付け直す workaround が必要になっていた。

詳細: #184

## 変更内容

### インフラ (CDK)
- `infra/config/index.ts`: `frontendDomain: string` フィールド追加
- `infra/config/dev.ts`: `frontendDomain: 'credit-checker.dev.jun-eg.site'`
- `infra/config/prod.ts`: `frontendDomain: 'credit-checker.jun-eg.site'`
- `infra/lib/edge/edge-stack.ts`:
  - CloudFront `domainNames` を `config.frontendDomain` に
  - Route53 `recordName` を `config.frontendDomain` に
  - Frontend ヘルスチェックパスを `/credit-checker` → `/` に
- `infra/lib/app/app-stack.ts`: ECS 環境変数を `frontendDomain` ベースに更新
  - `AUTH_URL`: `https://{frontendDomain}/api/auth`
  - `BACKEND_URL` / `NEXT_PUBLIC_BACKEND_URL`: `https://{frontendDomain}/api/v1`
  - `FRONTEND_URL` (backend 向け CORS): `https://{frontendDomain}`

### フロントエンド
- `next.config.ts`: `basePath` 削除、`allowedOrigins` を subdomain に
- `middleware.ts`: basePath 関連 workaround を全て撤去し標準パターンに戻す
- `src/app/page.tsx`: `signIn` の `redirectTo` を `/select` に
- `src/components/AppHeader.tsx`: `signOut` の `redirectTo` を `/` に
- `src/contexts/ModeContext.tsx`: Cookie path を `/` に
- `src/app/api/auth/[...nextauth]/route.ts`: `restoreBasePath` 関数を削除し `handlers` をそのまま re-export

### その他
- `.env.example`: `AUTH_URL=http://localhost:3000/api/auth` に更新

## 証明書・DNS について

既存の ACM 証明書が wildcard SAN (`*.dev.jun-eg.site`, `*.jun-eg.site`) を持っているため、新規発行は不要。Route53 も同じ hosted zone 内で新しい record を追加するだけ。

## 手動対応が必要な項目

**Google Cloud Console の OAuth Authorized redirect URI を追加**:
- 追加: `https://credit-checker.dev.jun-eg.site/api/auth/callback/google`
- 追加: `https://credit-checker.jun-eg.site/api/auth/callback/google`
- デプロイ前に登録しておくこと

## デプロイ順

1. この PR を merge（CI 自動デプロイ）
2. CDK が CloudFront `domainNames` / Route53 record / ECS task definition を更新
3. CloudFront 再配布が完了（5〜20分）
4. `https://credit-checker.dev.jun-eg.site/` で動作確認

## 破棄される URL

旧 URL `https://dev.jun-eg.site/credit-checker/*` は使えなくなる（dev 環境のため問題なし）。

## Test plan
- [ ] CI で next build / cdk synth 相当が通ること
- [ ] デプロイ後 `https://credit-checker.dev.jun-eg.site/` にアクセスしてログイン画面が表示される
- [ ] Google OAuth でログインでき、`/select` に遷移する
- [ ] 個人/Room モードが選択でき `/dashboard` に遷移する
- [ ] 未認証で `/dashboard` にアクセス → `/` にリダイレクトされる
- [ ] middleware のリダイレクト先が正しいドメインになる

Closes #184

🤖 Generated with [Claude Code](https://claude.com/claude-code)