### PR TITLE
add: 期限付き招待リンク機能の実装 (#186)

### DIFF
--- a/apps/backend/src/app.module.ts
+++ b/apps/backend/src/app.module.ts
@@ -11,6 +11,7 @@ import { Receipt } from './entities/receipt.entity';
 import { ReceiptItem } from './entities/receipt-item.entity';
 import { Room } from './entities/room.entity';
 import { RoomMember } from './entities/room-member.entity';
+import { RoomInvitation } from './entities/room-invitation.entity';
 import { User } from './entities/user.entity';
 import { UsersModule } from './users/users.module';
 import { ChatModule } from './chat/chat.module';
@@ -34,7 +35,7 @@ import { secrets } from './config/secrets';
       useFactory: (config: ConfigService) => ({
         type: 'postgres',
         url: secrets.databaseUrl(),
-        entities: [User, Receipt, ReceiptItem, ChatSession, ChatMessage, Room, RoomMember],
+        entities: [User, Receipt, ReceiptItem, ChatSession, ChatMessage, Room, RoomMember, RoomInvitation],
         migrations: ['dist/migrations/*.js'],
         synchronize: false,
         logging: process.env.TYPEORM_LOGGING === 'true',

--- a/apps/backend/src/database/data-source.ts
+++ b/apps/backend/src/database/data-source.ts
@@ -6,11 +6,12 @@ import { ChatSession } from '../entities/chat-session.entity';
 import { ChatMessage } from '../entities/chat-message.entity';
 import { Room } from '../entities/room.entity';
 import { RoomMember } from '../entities/room-member.entity';
+import { RoomInvitation } from '../entities/room-invitation.entity';
 
 export const AppDataSource = new DataSource({
   type: 'postgres',
   url: process.env.DATABASE_URL,
-  entities: [User, Receipt, ReceiptItem, ChatSession, ChatMessage, Room, RoomMember],
+  entities: [User, Receipt, ReceiptItem, ChatSession, ChatMessage, Room, RoomMember, RoomInvitation],
   migrations: ['dist/migrations/*.js'],
   synchronize: false,
   logging: process.env.TYPEORM_LOGGING === 'true',

--- a/apps/backend/src/entities/room-invitation.entity.ts
+++ b/apps/backend/src/entities/room-invitation.entity.ts
@@ -1,0 +1,49 @@
+import {
+  Column,
+  CreateDateColumn,
+  Entity,
+  JoinColumn,
+  ManyToOne,
+  PrimaryGeneratedColumn,
+} from 'typeorm';
+import { Room } from './room.entity';
+import { User } from './user.entity';
+
+@Entity('room_invitations')
+export class RoomInvitation {
+  @PrimaryGeneratedColumn('uuid')
+  id: string;
+
+  @Column({ name: 'room_id' })
+  roomId: string;
+
+  @Column({ type: 'varchar', length: 64, unique: true })
+  token: string;
+
+  @Column({ name: 'created_by' })
+  createdBy: string;
+
+  @Column({ name: 'expires_at', type: 'timestamptz' })
+  expiresAt: Date;
+
+  @Column({ name: 'used_by', type: 'uuid', nullable: true })
+  usedBy: string | null;
+
+  @Column({ name: 'used_at', type: 'timestamptz', nullable: true })
+  usedAt: Date | null;
+
+  @CreateDateColumn({ name: 'created_at', type: 'timestamptz' })
+  createdAt: Date;
+
+  @ManyToOne(() => Room, { onDelete: 'CASCADE' })
+  @JoinColumn({ name: 'room_id' })
+  room: Room;
+
+  @ManyToOne(() => User, { onDelete: 'CASCADE' })
+  @JoinColumn({ name: 'created_by' })
+  creator: User;
+
+  @ManyToOne(() => User, { onDelete: 'SET NULL', nullable: true })
+  @JoinColumn({ name: 'used_by' })
+  usedByUser: User | null;
+}

--- a/apps/backend/src/migrations/1776249600000-AddRoomInvitations.ts
+++ b/apps/backend/src/migrations/1776249600000-AddRoomInvitations.ts
@@ -1,0 +1,29 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+export class AddRoomInvitations1776249600000 implements MigrationInterface {
+  name = 'AddRoomInvitations1776249600000';
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`
+      CREATE TABLE "room_invitations" (
+        "id"         UUID DEFAULT gen_random_uuid() PRIMARY KEY,
+        "room_id"    UUID NOT NULL REFERENCES "rooms"("id") ON DELETE CASCADE,
+        "token"      VARCHAR(64) NOT NULL UNIQUE,
+        "created_by" UUID NOT NULL REFERENCES "users"("id") ON DELETE CASCADE,
+        "expires_at" TIMESTAMPTZ NOT NULL,
+        "used_by"    UUID REFERENCES "users"("id") ON DELETE SET NULL,
+        "used_at"    TIMESTAMPTZ,
+        "created_at" TIMESTAMPTZ NOT NULL DEFAULT now()
+      )
+    `);
+
+    await queryRunner.query(
+      `CREATE INDEX "idx_room_invitations_room_expires" ON "room_invitations"("room_id", "expires_at")`,
+    );
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`DROP INDEX "idx_room_invitations_room_expires"`);
+    await queryRunner.query(`DROP TABLE "room_invitations"`);
+  }
+}

--- a/apps/backend/src/rooms/dto/issue-invitation.response.dto.ts
+++ b/apps/backend/src/rooms/dto/issue-invitation.response.dto.ts
@@ -1,0 +1,5 @@
+export class IssueInvitationResponseDto {
+  token: string;
+  url: string;
+  expiresAt: Date;
+}

--- a/apps/backend/src/rooms/rooms.controller.ts
+++ b/apps/backend/src/rooms/rooms.controller.ts
@@ -14,6 +14,7 @@ import { CurrentUser } from '../common/decorators/current-user.decorator';
 import { User } from '../entities/user.entity';
 import { RoomMemberRole } from '../entities/room-member.entity';
 import { CreateRoomRequestDto } from './dto/create-room.request.dto';
+import { IssueInvitationResponseDto } from './dto/issue-invitation.response.dto';
 import { JoinRoomRequestDto } from './dto/join-room.request.dto';
 import { RoomDetailResponseDto, RoomResponseDto } from './dto/room.response.dto';
 import { ListRoomReceiptsResponseDto } from './dto/room-receipt.response.dto';
@@ -67,6 +68,22 @@ export class RoomsController {
     };
   }
 
+  // /rooms/:id との衝突を避けるため、literal prefix の invitations ルートを先に定義
+  @Post('invitations/:token/accept')
+  async acceptInvitation(
+    @CurrentUser() user: User,
+    @Param('token') token: string,
+  ): Promise<RoomResponseDto> {
+    const room = await this.roomsService.acceptInvitation(token, user.id);
+    return {
+      id: room.id,
+      name: room.name,
+      ownerId: room.ownerId,
+      memberCount: room.members?.length ?? 0,
+      createdAt: room.createdAt,
+    };
+  }
+
   @Post(':id/invite-code/regenerate')
   async regenerateInviteCode(
     @CurrentUser() user: User,
@@ -74,6 +91,22 @@ export class RoomsController {
   ): Promise<{ inviteCode: string }> {
     const room = await this.roomsService.regenerateInviteCode(id, user.id);
     return { inviteCode: room.inviteCode };
+  }
+
+  @Post(':id/invitations')
+  async issueInvitation(
+    @CurrentUser() user: User,
+    @Param('id', ParseUUIDPipe) id: string,
+  ): Promise<IssueInvitationResponseDto> {
+    const { invitation, url } = await this.roomsService.issueInvitation(
+      id,
+      user.id,
+    );
+    return {
+      token: invitation.token,
+      url,
+      expiresAt: invitation.expiresAt,
+    };
   }
 
   @Get(':id/receipts')

--- a/apps/backend/src/rooms/rooms.module.ts
+++ b/apps/backend/src/rooms/rooms.module.ts
@@ -3,13 +3,14 @@ import { TypeOrmModule } from '@nestjs/typeorm';
 import { AuthModule } from '../auth/auth.module';
 import { Room } from '../entities/room.entity';
 import { RoomMember } from '../entities/room-member.entity';
+import { RoomInvitation } from '../entities/room-invitation.entity';
 import { Receipt } from '../entities/receipt.entity';
 import { RoomsController } from './rooms.controller';
 import { RoomsService } from './rooms.service';
 
 @Module({
   imports: [
-    TypeOrmModule.forFeature([Room, RoomMember, Receipt]),
+    TypeOrmModule.forFeature([Room, RoomMember, RoomInvitation, Receipt]),
     AuthModule,
   ],
   controllers: [RoomsController],

--- a/apps/backend/src/rooms/rooms.service.ts
+++ b/apps/backend/src/rooms/rooms.service.ts
@@ -1,6 +1,8 @@
+import { randomBytes } from 'crypto';
 import {
   ConflictException,
   ForbiddenException,
+  GoneException,
   Injectable,
   NotFoundException,
 } from '@nestjs/common';
@@ -8,7 +10,12 @@ import { InjectRepository } from '@nestjs/typeorm';
 import { Repository } from 'typeorm';
 import { Room } from '../entities/room.entity';
 import { RoomMember, RoomMemberRole } from '../entities/room-member.entity';
+import { RoomInvitation } from '../entities/room-invitation.entity';
 import { Receipt } from '../entities/receipt.entity';
+
+// 招待リンクは発行から30分で失効する
+const INVITATION_TTL_MS = 30 * 60 * 1000;
+
 @Injectable()
 export class RoomsService {
   constructor(
@@ -16,6 +23,8 @@ export class RoomsService {
     private readonly roomsRepository: Repository<Room>,
     @InjectRepository(RoomMember)
     private readonly roomMembersRepository: Repository<RoomMember>,
+    @InjectRepository(RoomInvitation)
+    private readonly roomInvitationsRepository: Repository<RoomInvitation>,
     @InjectRepository(Receipt)
     private readonly receiptsRepository: Repository<Receipt>,
   ) {}
@@ -165,5 +174,99 @@ export class RoomsService {
     return Array.from({ length: 8 }, () =>
       chars.charAt(Math.floor(Math.random() * chars.length)),
     ).join('');
+  }
+
+  async issueInvitation(
+    roomId: string,
+    userId: string,
+  ): Promise<{ invitation: RoomInvitation; url: string }> {
+    const member = await this.roomMembersRepository.findOne({
+      where: { roomId, userId },
+    });
+    // 招待リンク発行はオーナーのみ許可
+    if (!member || member.role !== RoomMemberRole.OWNER) {
+      throw new ForbiddenException('招待リンクの発行はオーナーのみ可能です');
+    }
+
+    const room = await this.roomsRepository.findOne({ where: { id: roomId } });
+    if (!room) {
+      throw new NotFoundException(`ルームが見つかりません: ${roomId}`);
+    }
+
+    const token = this.generateInvitationToken();
+    const expiresAt = new Date(Date.now() + INVITATION_TTL_MS);
+
+    const invitation = this.roomInvitationsRepository.create({
+      roomId,
+      token,
+      createdBy: userId,
+      expiresAt,
+      usedBy: null,
+      usedAt: null,
+    });
+    const saved = await this.roomInvitationsRepository.save(invitation);
+
+    return { invitation: saved, url: this.buildInvitationUrl(token) };
+  }
+
+  async acceptInvitation(token: string, userId: string): Promise<Room> {
+    return this.roomInvitationsRepository.manager.transaction(async (manager) => {
+      // 同時に同じトークンを使おうとするリクエストを直列化するため、行ロックで読む
+      const invitation = await manager
+        .getRepository(RoomInvitation)
+        .createQueryBuilder('inv')
+        .setLock('pessimistic_write')
+        .where('inv.token = :token', { token })
+        .getOne();
+
+      if (!invitation) {
+        throw new NotFoundException('招待リンクが見つかりません');
+      }
+      if (invitation.expiresAt.getTime() <= Date.now()) {
+        throw new GoneException('招待リンクの有効期限が切れています');
+      }
+      if (invitation.usedBy) {
+        throw new ConflictException('この招待リンクは既に使用されています');
+      }
+
+      const existing = await manager.getRepository(RoomMember).findOne({
+        where: { roomId: invitation.roomId, userId },
+      });
+      // 既メンバーの場合は招待リンクを消費せず、冪等的にエラーとする
+      if (existing) {
+        throw new ConflictException('既にこのルームのメンバーです');
+      }
+
+      invitation.usedBy = userId;
+      invitation.usedAt = new Date();
+      await manager.getRepository(RoomInvitation).save(invitation);
+
+      const newMember = manager.getRepository(RoomMember).create({
+        roomId: invitation.roomId,
+        userId,
+        role: RoomMemberRole.MEMBER,
+      });
+      await manager.getRepository(RoomMember).save(newMember);
+
+      const room = await manager
+        .getRepository(Room)
+        .findOne({ where: { id: invitation.roomId } });
+      if (!room) {
+        throw new NotFoundException('ルームが見つかりません');
+      }
+      return room;
+    });
+  }
+
+  // URL-safe base64 で 256bit のランダムトークンを生成する（43文字）
+  private generateInvitationToken(): string {
+    return randomBytes(32).toString('base64url');
+  }
+
+  private buildInvitationUrl(token: string): string {
+    const base = process.env.FRONTEND_URL ?? '';
+    // 末尾スラッシュの重複を避ける
+    const normalized = base.replace(/\/$/, '');
+    return `${normalized}/rooms/join?token=${token}`;
   }
 }

--- a/apps/frontend/src/app/rooms/[id]/_components/InvitationLinkPanel.tsx
+++ b/apps/frontend/src/app/rooms/[id]/_components/InvitationLinkPanel.tsx
@@ -1,0 +1,120 @@
+'use client';
+
+import { useEffect, useState, useTransition } from 'react';
+import { RoomInvitation } from '../../../../types/room';
+import { issueRoomInvitation } from '../../../../lib/api/rooms';
+
+interface InvitationLinkPanelProps {
+  roomId: string;
+  backendToken: string;
+}
+
+interface CountdownState {
+  label: string;
+  expired: boolean;
+}
+
+function formatCountdown(expiresAt: string): CountdownState {
+  const remainingMs = new Date(expiresAt).getTime() - Date.now();
+  if (remainingMs <= 0) {
+    return { label: '失効済み', expired: true };
+  }
+  const totalSeconds = Math.floor(remainingMs / 1000);
+  const minutes = Math.floor(totalSeconds / 60);
+  const seconds = totalSeconds % 60;
+  return {
+    label: `残り ${minutes}:${seconds.toString().padStart(2, '0')}`,
+    expired: false,
+  };
+}
+
+export function InvitationLinkPanel({ roomId, backendToken }: InvitationLinkPanelProps) {
+  const [invitation, setInvitation] = useState<RoomInvitation | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const [copied, setCopied] = useState(false);
+  const [countdown, setCountdown] = useState<CountdownState | null>(null);
+  const [isPending, startTransition] = useTransition();
+
+  useEffect(() => {
+    if (!invitation) {
+      setCountdown(null);
+      return;
+    }
+    // 1秒ごとに残り時間を再計算する（失効後も1度更新するため即時更新→interval）
+    const update = () => setCountdown(formatCountdown(invitation.expiresAt));
+    update();
+    const id = window.setInterval(update, 1000);
+    return () => window.clearInterval(id);
+  }, [invitation]);
+
+  const handleIssue = () => {
+    startTransition(async () => {
+      setError(null);
+      setCopied(false);
+      try {
+        const result = await issueRoomInvitation(roomId, backendToken);
+        setInvitation(result);
+      } catch (e) {
+        setError(e instanceof Error ? e.message : '招待リンクの発行に失敗しました');
+      }
+    });
+  };
+
+  const handleCopy = async () => {
+    if (!invitation) return;
+    await navigator.clipboard.writeText(invitation.url);
+    setCopied(true);
+    window.setTimeout(() => setCopied(false), 2000);
+  };
+
+  return (
+    <div className="space-y-3">
+      <div className="flex items-center gap-2">
+        <button
+          type="button"
+          onClick={handleIssue}
+          disabled={isPending}
+          className="rounded-lg bg-zinc-900 px-3 py-1.5 text-sm font-medium text-white transition-colors hover:bg-zinc-700 disabled:opacity-50 dark:bg-zinc-50 dark:text-zinc-900 dark:hover:bg-zinc-200"
+        >
+          {isPending
+            ? '発行中…'
+            : invitation
+              ? '新しい招待リンクを発行'
+              : '招待リンクを発行'}
+        </button>
+        <span className="text-xs text-zinc-500 dark:text-zinc-400">
+          有効期限 30分 / 1人のみ参加可能
+        </span>
+      </div>
+
+      {error && <p className="text-sm text-red-500">{error}</p>}
+
+      {invitation && (
+        <div className="space-y-2 rounded-lg border border-zinc-200 bg-zinc-50 p-3 dark:border-zinc-800 dark:bg-zinc-950">
+          <div className="flex items-center gap-2">
+            <input
+              type="text"
+              readOnly
+              value={invitation.url}
+              className="w-full min-w-0 flex-1 rounded border border-zinc-200 bg-white px-2 py-1 font-mono text-xs text-zinc-700 dark:border-zinc-700 dark:bg-zinc-900 dark:text-zinc-300"
+              onFocus={(e) => e.currentTarget.select()}
+            />
+            <button
+              type="button"
+              onClick={handleCopy}
+              disabled={countdown?.expired}
+              className="shrink-0 rounded px-2 py-1 text-xs text-zinc-500 transition-colors hover:bg-zinc-100 hover:text-zinc-900 disabled:opacity-50 dark:text-zinc-400 dark:hover:bg-zinc-800 dark:hover:text-zinc-50"
+            >
+              {copied ? 'コピーしました' : 'コピー'}
+            </button>
+          </div>
+          <p
+            className={`text-xs ${countdown?.expired ? 'text-red-500' : 'text-zinc-500 dark:text-zinc-400'}`}
+          >
+            {countdown?.label ?? ''}
+          </p>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/apps/frontend/src/app/rooms/[id]/_components/InvitationLinkPanel.tsx
+++ b/apps/frontend/src/app/rooms/[id]/_components/InvitationLinkPanel.tsx
@@ -14,8 +14,8 @@ interface CountdownState {
   expired: boolean;
 }
 
-function formatCountdown(expiresAt: string): CountdownState {
-  const remainingMs = new Date(expiresAt).getTime() - Date.now();
+function formatCountdown(expiresAt: string, now: number): CountdownState {
+  const remainingMs = new Date(expiresAt).getTime() - now;
   if (remainingMs <= 0) {
     return { label: '失効済み', expired: true };
   }
@@ -32,20 +32,19 @@ export function InvitationLinkPanel({ roomId, backendToken }: InvitationLinkPane
   const [invitation, setInvitation] = useState<RoomInvitation | null>(null);
   const [error, setError] = useState<string | null>(null);
   const [copied, setCopied] = useState(false);
-  const [countdown, setCountdown] = useState<CountdownState | null>(null);
+  // カウントダウンは invitation と now から描画中に派生するため、now を interval で進めて再描画を起こす
+  const [now, setNow] = useState<number>(() => Date.now());
   const [isPending, startTransition] = useTransition();
 
   useEffect(() => {
-    if (!invitation) {
-      setCountdown(null);
-      return;
-    }
-    // 1秒ごとに残り時間を再計算する（失効後も1度更新するため即時更新→interval）
-    const update = () => setCountdown(formatCountdown(invitation.expiresAt));
-    update();
-    const id = window.setInterval(update, 1000);
+    if (!invitation) return;
+    const id = window.setInterval(() => setNow(Date.now()), 1000);
     return () => window.clearInterval(id);
   }, [invitation]);
+
+  const countdown: CountdownState | null = invitation
+    ? formatCountdown(invitation.expiresAt, now)
+    : null;
 
   const handleIssue = () => {
     startTransition(async () => {

--- a/apps/frontend/src/app/rooms/[id]/page.tsx
+++ b/apps/frontend/src/app/rooms/[id]/page.tsx
@@ -3,6 +3,7 @@ import { notFound, redirect } from 'next/navigation';
 import { auth } from '../../../../auth';
 import { AppHeader } from '../../../components/AppHeader';
 import { getRoom } from '../../../lib/api/rooms';
+import { InvitationLinkPanel } from './_components/InvitationLinkPanel';
 import { InviteCodeDisplay } from './_components/InviteCodeDisplay';
 import { RoomActions } from './_components/RoomActions';
 
@@ -80,6 +81,16 @@ export default async function RoomDetailPage({ params }: RoomDetailPageProps) {
                 招待コード
               </h2>
               <InviteCodeDisplay inviteCode={room.inviteCode} />
+            </div>
+          )}
+
+          {/* 期限付き招待リンク（オーナーのみ） */}
+          {isOwner && (
+            <div className="border-b border-zinc-100 px-4 py-4 sm:px-8 dark:border-zinc-800">
+              <h2 className="mb-2 text-sm font-medium text-zinc-500 dark:text-zinc-400">
+                招待リンク（期限付き）
+              </h2>
+              <InvitationLinkPanel roomId={room.id} backendToken={session.backendToken} />
             </div>
           )}
 

--- a/apps/frontend/src/app/rooms/join/_components/AcceptInvitationForm.tsx
+++ b/apps/frontend/src/app/rooms/join/_components/AcceptInvitationForm.tsx
@@ -1,0 +1,94 @@
+'use client';
+
+import Link from 'next/link';
+import { useRouter } from 'next/navigation';
+import { useState, useTransition } from 'react';
+import {
+  AcceptInvitationError,
+  AcceptInvitationErrorCode,
+  Room,
+} from '../../../../types/room';
+import { acceptRoomInvitation } from '../../../../lib/api/rooms';
+
+interface AcceptInvitationFormProps {
+  token: string;
+  backendToken: string;
+}
+
+interface ErrorState {
+  code: AcceptInvitationErrorCode;
+  message: string;
+}
+
+export function AcceptInvitationForm({
+  token,
+  backendToken,
+}: AcceptInvitationFormProps) {
+  const router = useRouter();
+  const [error, setError] = useState<ErrorState | null>(null);
+  const [joinedRoom, setJoinedRoom] = useState<Room | null>(null);
+  const [isPending, startTransition] = useTransition();
+
+  const handleAccept = () => {
+    startTransition(async () => {
+      setError(null);
+      try {
+        const room = await acceptRoomInvitation(token, backendToken);
+        setJoinedRoom(room);
+        router.push(`/rooms/${room.id}`);
+      } catch (e) {
+        if (e instanceof AcceptInvitationError) {
+          setError({ code: e.code, message: e.message });
+        } else {
+          setError({
+            code: 'unknown',
+            message: e instanceof Error ? e.message : '招待リンクの受諾に失敗しました',
+          });
+        }
+      }
+    });
+  };
+
+  // 参加成功後に router.push が遷移するまでの間だけ表示される
+  if (joinedRoom) {
+    return (
+      <p className="mt-4 text-sm text-zinc-500 dark:text-zinc-400">
+        ルーム「{joinedRoom.name}」に参加しました。画面を切り替えています…
+      </p>
+    );
+  }
+
+  if (error) {
+    return (
+      <div className="mt-4 space-y-3">
+        <p className="text-sm text-red-500">{error.message}</p>
+        {error.code === 'already_member' ? (
+          <Link
+            href="/rooms"
+            className="inline-block rounded-lg bg-zinc-900 px-4 py-2 text-sm font-medium text-white transition-colors hover:bg-zinc-700 dark:bg-zinc-50 dark:text-zinc-900 dark:hover:bg-zinc-200"
+          >
+            ルーム一覧を開く
+          </Link>
+        ) : (
+          <Link
+            href="/rooms"
+            className="inline-block text-sm text-zinc-700 underline dark:text-zinc-300"
+          >
+            ルーム一覧に戻る
+          </Link>
+        )}
+      </div>
+    );
+  }
+
+  return (
+    <button
+      type="button"
+      onClick={handleAccept}
+      disabled={isPending}
+      className="mt-4 w-full rounded-lg bg-zinc-900 px-4 py-2 text-sm font-medium text-white transition-colors hover:bg-zinc-700 disabled:opacity-50 dark:bg-zinc-50 dark:text-zinc-900 dark:hover:bg-zinc-200"
+    >
+      {isPending ? '参加中…' : '参加する'}
+    </button>
+  );
+}

--- a/apps/frontend/src/app/rooms/join/page.tsx
+++ b/apps/frontend/src/app/rooms/join/page.tsx
@@ -1,0 +1,88 @@
+import Link from 'next/link';
+import { auth, signIn } from '../../../../auth';
+import { AppHeader } from '../../../components/AppHeader';
+import { AcceptInvitationForm } from './_components/AcceptInvitationForm';
+
+interface JoinRoomPageProps {
+  searchParams: Promise<{ token?: string }>;
+}
+
+export default async function JoinRoomPage({ searchParams }: JoinRoomPageProps) {
+  const { token } = await searchParams;
+  const session = await auth();
+
+  // トークンが欠けているケース
+  if (!token) {
+    return (
+      <div className="min-h-screen bg-zinc-50 dark:bg-black">
+        <AppHeader currentPath="/rooms/join" />
+        <main className="mx-auto max-w-md space-y-4 px-4 py-10">
+          <div className="rounded-2xl bg-white p-6 shadow-sm dark:bg-zinc-900">
+            <h1 className="text-lg font-semibold text-zinc-900 dark:text-zinc-50">
+              招待リンクが無効です
+            </h1>
+            <p className="mt-2 text-sm text-zinc-500 dark:text-zinc-400">
+              トークンが含まれていません。招待リンクを発行したオーナーに確認してください。
+            </p>
+            <Link
+              href="/rooms"
+              className="mt-4 inline-block text-sm text-zinc-700 underline dark:text-zinc-300"
+            >
+              ルーム一覧に戻る
+            </Link>
+          </div>
+        </main>
+      </div>
+    );
+  }
+
+  // 未ログイン時はログイン後に同じ招待URLへ戻す
+  if (!session) {
+    const callbackUrl = `/rooms/join?token=${encodeURIComponent(token)}`;
+    const handleSignIn = async () => {
+      'use server';
+      await signIn('google', { redirectTo: callbackUrl });
+    };
+
+    return (
+      <div className="min-h-screen bg-zinc-50 dark:bg-black">
+        <AppHeader currentPath="/rooms/join" />
+        <main className="mx-auto max-w-md space-y-4 px-4 py-10">
+          <div className="rounded-2xl bg-white p-6 shadow-sm dark:bg-zinc-900">
+            <h1 className="text-lg font-semibold text-zinc-900 dark:text-zinc-50">
+              ルームに招待されています
+            </h1>
+            <p className="mt-2 text-sm text-zinc-500 dark:text-zinc-400">
+              参加するにはログインしてください。
+            </p>
+            <form action={handleSignIn} className="mt-4">
+              <button
+                type="submit"
+                className="w-full rounded-lg bg-zinc-900 px-4 py-2 text-sm font-medium text-white transition-colors hover:bg-zinc-700 dark:bg-zinc-50 dark:text-zinc-900 dark:hover:bg-zinc-200"
+              >
+                Google でログインして参加
+              </button>
+            </form>
+          </div>
+        </main>
+      </div>
+    );
+  }
+
+  return (
+    <div className="min-h-screen bg-zinc-50 dark:bg-black">
+      <AppHeader currentPath="/rooms/join" />
+      <main className="mx-auto max-w-md space-y-4 px-4 py-10">
+        <div className="rounded-2xl bg-white p-6 shadow-sm dark:bg-zinc-900">
+          <h1 className="text-lg font-semibold text-zinc-900 dark:text-zinc-50">
+            ルームに参加
+          </h1>
+          <p className="mt-2 text-sm text-zinc-500 dark:text-zinc-400">
+            招待リンクからルームに参加します。下のボタンを押して参加してください。
+          </p>
+          <AcceptInvitationForm token={token} backendToken={session.backendToken} />
+        </div>
+      </main>
+    </div>
+  );
+}

--- a/apps/frontend/src/lib/api/rooms.ts
+++ b/apps/frontend/src/lib/api/rooms.ts
@@ -1,4 +1,11 @@
-import { Room, RoomDetail, RoomReceiptItem } from '../../types/room';
+import {
+  AcceptInvitationError,
+  AcceptInvitationErrorCode,
+  Room,
+  RoomDetail,
+  RoomInvitation,
+  RoomReceiptItem,
+} from '../../types/room';
 
 // SSR: BACKEND_URL（サーバー側env var）でバックエンドに直接通信
 // クライアント: /api/v1 の相対パス（本番はALBが転送、ローカルはNext.js rewriteがプロキシ）
@@ -106,4 +113,67 @@ export async function listRoomReceipts(
 
   const data = (await res.json()) as { items: RoomReceiptItem[] };
   return data.items;
+}
+
+export async function issueRoomInvitation(
+  roomId: string,
+  backendToken: string,
+): Promise<RoomInvitation> {
+  const res = await fetch(`${backendUrl}/rooms/${roomId}/invitations`, {
+    method: 'POST',
+    headers: { Authorization: `Bearer ${backendToken}` },
+  });
+
+  if (!res.ok) {
+    const text = await res.text();
+    throw new Error(`招待リンクの発行に失敗しました (${res.status}): ${text}`);
+  }
+
+  return res.json() as Promise<RoomInvitation>;
+}
+
+// エラー種別をサーバー応答のステータスコードから判別する
+function resolveAcceptInvitationError(
+  status: number,
+  body: string,
+): AcceptInvitationError {
+  const codeByStatus: Record<number, AcceptInvitationErrorCode> = {
+    401: 'unauthorized',
+    404: 'not_found',
+    410: 'expired',
+  };
+  let code: AcceptInvitationErrorCode = codeByStatus[status] ?? 'unknown';
+  // 409 は「使用済み」と「既メンバー」のいずれか。サーバーメッセージで判別する
+  if (status === 409) {
+    code = /既に.*メンバー/.test(body) ? 'already_member' : 'already_used';
+  }
+  const messageByCode: Record<AcceptInvitationErrorCode, string> = {
+    not_found: '招待リンクが無効です',
+    expired: '招待リンクの有効期限が切れています',
+    already_used: 'この招待リンクは既に使用されています',
+    already_member: 'すでにこのルームのメンバーです',
+    unauthorized: 'ログインが必要です',
+    unknown: `招待リンクの受諾に失敗しました (${status})`,
+  };
+  return new AcceptInvitationError(code, messageByCode[code]);
+}
+
+export async function acceptRoomInvitation(
+  invitationToken: string,
+  backendToken: string,
+): Promise<Room> {
+  const res = await fetch(
+    `${backendUrl}/rooms/invitations/${encodeURIComponent(invitationToken)}/accept`,
+    {
+      method: 'POST',
+      headers: { Authorization: `Bearer ${backendToken}` },
+    },
+  );
+
+  if (!res.ok) {
+    const text = await res.text();
+    throw resolveAcceptInvitationError(res.status, text);
+  }
+
+  return res.json() as Promise<Room>;
 }

--- a/apps/frontend/src/types/room.ts
+++ b/apps/frontend/src/types/room.ts
@@ -40,3 +40,27 @@ export interface RoomReceiptItem {
   currency: string | null;
   createdAt: string;
 }
+
+export interface RoomInvitation {
+  token: string;
+  url: string;
+  expiresAt: string;
+}
+
+export type AcceptInvitationErrorCode =
+  | 'not_found'
+  | 'expired'
+  | 'already_used'
+  | 'already_member'
+  | 'unauthorized'
+  | 'unknown';
+
+export class AcceptInvitationError extends Error {
+  readonly code: AcceptInvitationErrorCode;
+
+  constructor(code: AcceptInvitationErrorCode, message: string) {
+    super(message);
+    this.name = 'AcceptInvitationError';
+    this.code = code;
+  }
+}


### PR DESCRIPTION
## Summary

親Issue jun-eg/credit-checker#186「期限付き招待リンク機能の実装」の全 Sub-issue (#187, #188, #189, #190) をまとめて対応する。既存の永続的な `inviteCode` と並立する形で、**30分で失効・1人のみ使用可能な招待リンク** を発行・共有・受諾できるようにする。

### 含まれる Sub-issue
- jun-eg/credit-checker#187 DB スキーマ: `room_invitations` テーブル追加
- jun-eg/credit-checker#188 Backend: 招待リンク発行・受諾 API 実装
- jun-eg/credit-checker#189 Frontend: 招待リンク発行 UI（ルーム詳細画面）
- jun-eg/credit-checker#190 Frontend: 招待リンク受諾ページ実装

## 主な変更

### #187 DB スキーマ
- `RoomInvitation` エンティティを新規作成（Room / User とのリレーション）
- TypeORM マイグレーション `1776249600000-AddRoomInvitations` を追加
- `app.module.ts` / `database/data-source.ts` の entities 配列に `RoomInvitation` を登録

#### テーブル定義
| カラム | 型 | 制約 |
|---|---|---|
| id | uuid | PK, default `gen_random_uuid()` |
| room_id | uuid | NOT NULL, FK → rooms.id ON DELETE CASCADE |
| token | varchar(64) | NOT NULL, UNIQUE |
| created_by | uuid | NOT NULL, FK → users.id ON DELETE CASCADE |
| expires_at | timestamptz | NOT NULL |
| used_by | uuid | NULL, FK → users.id ON DELETE SET NULL |
| used_at | timestamptz | NULL |
| created_at | timestamptz | NOT NULL, default `now()` |

インデックス: `token` UNIQUE、`(room_id, expires_at)` btree

### #188 Backend API
- `POST /rooms/:id/invitations` — オーナー向けに招待リンクを発行
  - レスポンス: `{ token, url, expiresAt }` （URL は `FRONTEND_URL/rooms/join?token=...`）
  - 有効期限は発行から30分（`INVITATION_TTL_MS`）
  - トークンは `crypto.randomBytes(32).toString('base64url')`（URL-safe, 256bit）
- `POST /rooms/invitations/:token/accept` — ログイン済みユーザーの受諾
  - `pessimistic_write` ロック付きトランザクションで二重使用を防止
  - エラー: `404 not_found` / `410 expired` / `409 already_used` / `409 already_member`
  - 既メンバーの場合は招待リンクを消費しない
- ルート定義順序: `POST /rooms/invitations/:token/accept` を `:id` 系ルートより前に置き衝突を回避

### #189 Frontend: 招待リンク発行 UI
- `apps/frontend/src/app/rooms/[id]/_components/InvitationLinkPanel.tsx` を新規作成
- ルーム詳細画面（オーナーのみ）に「招待リンクを発行」ボタンと発行結果パネルを追加
  - 発行URLを readonly input + 手動コピーボタンで表示（クリップボード API）
  - `setInterval` で1秒ごとに残り時間を `分:秒` 表示
  - 失効時は表示を赤字「失効済み」に変更し、コピーボタンを無効化
  - 「新しい招待リンクを発行」ボタンで再発行可能
- 既存の永続招待コード (`InviteCodeDisplay`) とは別セクションとして並置

### #190 Frontend: 招待リンク受諾ページ
- `apps/frontend/src/app/rooms/join/page.tsx` を新規作成
  - `?token=XXX` から招待トークンを取得
  - **未ログイン**: Google ログインフォームを表示し、`redirectTo` に同URLを渡して戻す
  - **ログイン済み**: `AcceptInvitationForm` を表示
- `apps/frontend/src/app/rooms/join/_components/AcceptInvitationForm.tsx` を新規作成（クライアント）
  - 「参加する」ボタンで `acceptRoomInvitation` を呼び、成功時に `/rooms/:id` へ遷移
  - エラー種別に応じてメッセージを出し分け
    - `not_found`: 招待リンクが無効です
    - `expired`: 招待リンクの有効期限が切れています
    - `already_used`: この招待リンクは既に使用されています
    - `already_member`: すでにこのルームのメンバーです → 「ルーム一覧を開く」 CTA

### 共通（Frontend 型 / API クライアント）
- `types/room.ts` に `RoomInvitation` と `AcceptInvitationError`, `AcceptInvitationErrorCode` を追加
- `lib/api/rooms.ts` に `issueRoomInvitation` と `acceptRoomInvitation` を追加
  - 受諾エラーは HTTP ステータスとサーバーメッセージから `AcceptInvitationError` を組み立てて throw
  - `409` は「既メンバー」と「使用済み」をレスポンス本文で判別

## Test plan

- [x] backend: `nest build` が成功する
- [x] frontend: `tsc --noEmit` による型チェックが成功する
- [x] ローカル PostgreSQL コンテナで `typeorm migration:run` を実行し、`room_invitations` テーブルのスキーマ（カラム・型・制約・FK・インデックス）を `\d room_invitations` で確認
- [x] `typeorm migration:revert` で down マイグレーションが成功し、テーブルが削除されることを確認
- [ ] 手動疎通: オーナーで招待リンクを発行 → 別ユーザーで `/rooms/join?token=...` を開いて参加 → ルーム詳細へ遷移
- [ ] 手動疎通: 発行30分後に受諾を試みると「有効期限切れ」エラー
- [ ] 手動疎通: 一度使われた招待リンクを再度使おうとすると「既に使用されています」エラー
- [ ] 手動疎通: 既メンバーが同じ招待リンクを踏むと「すでにメンバー」エラー + 「ルーム一覧を開く」CTA 表示
- [ ] 手動疎通: 未ログインで `/rooms/join?token=...` を開くとログイン導線が表示され、ログイン後に受諾フローへ戻る

## 関連

- Parent issue: jun-eg/credit-checker#186
- Sub-issues: jun-eg/credit-checker#187, jun-eg/credit-checker#188, jun-eg/credit-checker#189, jun-eg/credit-checker#190

🤖 Generated with [Claude Code](https://claude.com/claude-code)
