### PR TITLE
add: ヘッダーにルーム設定リンクを追加し詳細画面への導線を復活 (#192)

### DIFF
--- a/apps/frontend/src/components/AppHeader.tsx
+++ b/apps/frontend/src/components/AppHeader.tsx
@@ -1,6 +1,7 @@
 import Link from 'next/link';
 import { signOut } from '../../auth';
 import { ExitButton } from './ExitButton';
+import { RoomSettingsNavLink } from './RoomSettingsNavLink';
 
 interface AppHeaderProps {
   currentPath?: string;
@@ -50,6 +51,7 @@ export function AppHeader({ currentPath }: AppHeaderProps) {
               >
                 チャット
               </Link>
+              <RoomSettingsNavLink />
             </nav>
           </div>
           <div className="flex items-center gap-4">

--- a/apps/frontend/src/components/RoomSettingsNavLink.tsx
+++ b/apps/frontend/src/components/RoomSettingsNavLink.tsx
@@ -1,0 +1,28 @@
+'use client';
+
+import Link from 'next/link';
+import { usePathname } from 'next/navigation';
+import { useMode } from '../contexts/ModeContext';
+
+export function RoomSettingsNavLink() {
+  const { mode } = useMode();
+  const pathname = usePathname();
+
+  if (mode?.type !== 'room') return null;
+
+  const href = `/rooms/${mode.room.id}`;
+  const isActive = pathname === href;
+
+  return (
+    <Link
+      href={href}
+      className={`text-sm transition-colors ${
+        isActive
+          ? 'text-zinc-900 dark:text-zinc-50'
+          : 'text-zinc-500 hover:text-zinc-900 dark:text-zinc-400 dark:hover:text-zinc-50'
+      }`}
+    >
+      ルーム設定
+    </Link>
+  );
+}


### PR DESCRIPTION
## Summary

- ルームモード時に `AppHeader` から `/rooms/:id`（ルーム詳細画面）へ遷移できるリンクを追加する
- PR #191 で実装された招待リンク発行UI (`InvitationLinkPanel.tsx`) はルーム詳細画面に配置されているが、現状はどこからもその画面へ遷移する導線が無く、事実上触れない状態だったのを解消する
- 個人モード時はリンク自体を描画しない

Closes jun-eg/credit-checker#192

## 実装内容

- `apps/frontend/src/components/RoomSettingsNavLink.tsx` を新規作成（Client Component）
  - `useMode()` で現在のモードを参照し、`type === 'room'` のときのみ `<Link href={/rooms/${mode.room.id}}>ルーム設定</Link>` を描画
  - `usePathname()` で現在のパスと比較し、ルーム詳細画面を開いているときは既存ナビと同じ配色でアクティブ状態を表示
- `apps/frontend/src/components/AppHeader.tsx` のナビ末尾（チャットの右）に `<RoomSettingsNavLink />` を配置
  - 既存の `currentPath` ベースのハイライトロジックは変更していない
  - ログアウト（Server Action form）や `ExitButton` の挙動も変更していない

## なぜ AppHeader (Server Component) に Client Component を挟むか

`AppHeader` は `signOut` の Server Action form を持っているため Server Component のまま残す必要がある。一方で `useMode()` は Client Context なので利用側は Client Component でなければならない。既存の `ExitButton` と同じパターンで、ナビ要素だけを Client Component 化した。

## Test plan

- [x] `npx tsc --noEmit` が成功する（frontend）
- [ ] ローカルでルームに入った状態で `/dashboard` / `/receipts` / `/chat` を開き、ヘッダーに「ルーム設定」リンクが表示される
- [ ] 「ルーム設定」クリックで `/rooms/:id` に遷移し、`InvitationLinkPanel` が表示される
- [ ] 個人モードに切り替えるとリンクが消える
- [ ] ルーム詳細画面を開いているときにリンクがアクティブ色になる
- [ ] 既存のダッシュボード / レシート / チャット / 退出 / ログアウトが従来通り動作する

🤖 Generated with [Claude Code](https://claude.com/claude-code)