### PR TITLE
fix: 招待リンクのミドルウェアリダイレクト問題を修正 #196

### DIFF
--- a/apps/frontend/middleware.ts
+++ b/apps/frontend/middleware.ts
@@ -1,13 +1,13 @@
 import { auth } from './auth';
 import { NextResponse } from 'next/server';
 
-const PUBLIC_PATHS = ['/', '/select'];
+const PUBLIC_PATHS = ['/', '/select', '/rooms/join'];
 
 export default auth((req) => {
   const { pathname } = req.nextUrl;
 
-  // 未認証: ログインページ以外はトップへ
-  if (!req.auth && pathname !== '/') {
+  // 未認証: パブリックパス以外はトップへ
+  if (!req.auth && !PUBLIC_PATHS.includes(pathname)) {
     return NextResponse.redirect(new URL('/', req.url));
   }
 


### PR DESCRIPTION
## Summary
- `middleware.ts` の `PUBLIC_PATHS` に `/rooms/join` を追加
- 未認証リダイレクト条件を `pathname !== '/'` から `!PUBLIC_PATHS.includes(pathname)` に変更
- これにより未認証・モード未選択の両方のリダイレクトをバイパスし、`/rooms/join` ページ側のログイン導線が正常に動作する

## Test plan
- [ ] 未認証状態で招待リンク (`/rooms/join?token=xxx`) を踏み、`/rooms/join` に到達すること
- [ ] ログイン後に同じ招待URLへリダイレクトされること
- [ ] 認証済み・`app-mode` cookie未設定で招待リンクを踏み、`/rooms/join` に到達できること
- [ ] 既存の保護ページ (`/rooms`, `/receipts`, `/dashboard`) への未認証アクセスは従来通り `/` にリダイレクトされること

Closes #196

🤖 Generated with [Claude Code](https://claude.com/claude-code)