### PR TITLE
add: オーナーがメンバーを退会させる機能を追加 #197

### DIFF
--- a/apps/backend/src/rooms/rooms.controller.ts
+++ b/apps/backend/src/rooms/rooms.controller.ts
@@ -174,4 +174,14 @@ export class RoomsController {
   ): Promise<void> {
     await this.roomsService.leaveRoom(id, user.id);
   }
+
+  @Delete(':id/members/:memberId')
+  @HttpCode(204)
+  async removeMember(
+    @CurrentUser() user: User,
+    @Param('id', ParseUUIDPipe) id: string,
+    @Param('memberId', ParseUUIDPipe) memberId: string,
+  ): Promise<void> {
+    await this.roomsService.removeMember(id, user.id, memberId);
+  }
 }

--- a/apps/backend/src/rooms/rooms.service.ts
+++ b/apps/backend/src/rooms/rooms.service.ts
@@ -109,6 +109,34 @@ export class RoomsService {
     await this.roomMembersRepository.remove(member);
   }
 
+  async removeMember(
+    roomId: string,
+    ownerUserId: string,
+    targetMemberId: string,
+  ): Promise<void> {
+    const ownerMember = await this.roomMembersRepository.findOne({
+      where: { roomId, userId: ownerUserId },
+    });
+    if (!ownerMember || ownerMember.role !== RoomMemberRole.OWNER) {
+      throw new ForbiddenException('メンバーの除外はオーナーのみ可能です');
+    }
+
+    const targetMember = await this.roomMembersRepository.findOne({
+      where: { id: targetMemberId, roomId },
+    });
+    if (!targetMember) {
+      throw new NotFoundException('対象メンバーが見つかりません');
+    }
+
+    if (targetMember.role === RoomMemberRole.OWNER) {
+      throw new ForbiddenException(
+        'オーナー自身は除外できません。ルームを解散してください',
+      );
+    }
+
+    await this.roomMembersRepository.remove(targetMember);
+  }
+
   async joinRoom(userId: string, inviteCode: string): Promise<Room> {
     const room = await this.roomsRepository.findOne({ where: { inviteCode } });
     if (!room) {

--- a/apps/frontend/src/app/rooms/[id]/_components/MemberList.tsx
+++ b/apps/frontend/src/app/rooms/[id]/_components/MemberList.tsx
@@ -1,0 +1,81 @@
+'use client';
+
+import { useState } from 'react';
+import { useRouter } from 'next/navigation';
+import { removeMember } from '../../../../lib/api/rooms';
+import { RoomMember } from '../../../../types/room';
+
+interface MemberListProps {
+  members: RoomMember[];
+  isOwner: boolean;
+  roomId: string;
+  backendToken: string;
+}
+
+export function MemberList({ members: initialMembers, isOwner, roomId, backendToken }: MemberListProps) {
+  const router = useRouter();
+  const [members, setMembers] = useState(initialMembers);
+  const [confirmTarget, setConfirmTarget] = useState<string | null>(null);
+  const [isRemoving, setIsRemoving] = useState(false);
+
+  const handleRemove = async (memberId: string) => {
+    setIsRemoving(true);
+    try {
+      await removeMember(roomId, memberId, backendToken);
+      setMembers((prev) => prev.filter((m) => m.id !== memberId));
+      setConfirmTarget(null);
+      router.refresh();
+    } catch {
+      // エラー時はダイアログを閉じて行をそのまま残す
+      setConfirmTarget(null);
+    } finally {
+      setIsRemoving(false);
+    }
+  };
+
+  return (
+    <ul className="space-y-2">
+      {members.map((member) => (
+        <li key={member.id} className="flex items-center gap-2">
+          <span className="text-sm text-zinc-900 dark:text-zinc-50">
+            {member.displayName ?? member.userId}
+          </span>
+          {member.role === 'owner' && (
+            <span className="rounded-full bg-zinc-100 px-2 py-0.5 text-xs text-zinc-500 dark:bg-zinc-800 dark:text-zinc-400">
+              オーナー
+            </span>
+          )}
+          {isOwner && member.role !== 'owner' && (
+            <>
+              {confirmTarget === member.id ? (
+                <span className="ml-auto flex items-center gap-1">
+                  <button
+                    onClick={() => setConfirmTarget(null)}
+                    disabled={isRemoving}
+                    className="rounded px-2 py-0.5 text-xs text-zinc-400 transition-colors hover:text-zinc-700 disabled:opacity-50 dark:hover:text-zinc-300"
+                  >
+                    取消
+                  </button>
+                  <button
+                    onClick={() => handleRemove(member.id)}
+                    disabled={isRemoving}
+                    className="rounded px-2 py-0.5 text-xs font-medium text-red-500 transition-colors hover:bg-red-50 disabled:opacity-50 dark:hover:bg-red-950"
+                  >
+                    {isRemoving ? '除外中...' : '除外する'}
+                  </button>
+                </span>
+              ) : (
+                <button
+                  onClick={() => setConfirmTarget(member.id)}
+                  className="ml-auto rounded px-2 py-0.5 text-xs text-zinc-400 transition-colors hover:bg-zinc-100 hover:text-red-500 dark:hover:bg-zinc-800"
+                >
+                  退会させる
+                </button>
+              )}
+            </>
+          )}
+        </li>
+      ))}
+    </ul>
+  );
+}

--- a/apps/frontend/src/app/rooms/[id]/page.tsx
+++ b/apps/frontend/src/app/rooms/[id]/page.tsx
@@ -5,6 +5,7 @@ import { AppHeader } from '../../../components/AppHeader';
 import { getRoom } from '../../../lib/api/rooms';
 import { InvitationLinkPanel } from './_components/InvitationLinkPanel';
 import { InviteCodeDisplay } from './_components/InviteCodeDisplay';
+import { MemberList } from './_components/MemberList';
 import { RoomActions } from './_components/RoomActions';
 
 interface RoomDetailPageProps {
@@ -58,20 +59,12 @@ export default async function RoomDetailPage({ params }: RoomDetailPageProps) {
             <h2 className="mb-3 text-sm font-medium text-zinc-500 dark:text-zinc-400">
               メンバー ({room.members.length}人)
             </h2>
-            <ul className="space-y-2">
-              {room.members.map((member) => (
-                <li key={member.id} className="flex items-center gap-2">
-                  <span className="text-sm text-zinc-900 dark:text-zinc-50">
-                    {member.displayName ?? member.userId}
-                  </span>
-                  {member.role === 'owner' && (
-                    <span className="rounded-full bg-zinc-100 px-2 py-0.5 text-xs text-zinc-500 dark:bg-zinc-800 dark:text-zinc-400">
-                      オーナー
-                    </span>
-                  )}
-                </li>
-              ))}
-            </ul>
+            <MemberList
+              members={room.members}
+              isOwner={isOwner}
+              roomId={room.id}
+              backendToken={session.backendToken}
+            />
           </div>
 
           {/* 招待コード（オーナーのみ） */}

--- a/apps/frontend/src/lib/api/rooms.ts
+++ b/apps/frontend/src/lib/api/rooms.ts
@@ -86,6 +86,22 @@ export async function leaveRoom(id: string, token: string): Promise<void> {
   }
 }
 
+export async function removeMember(
+  roomId: string,
+  memberId: string,
+  token: string,
+): Promise<void> {
+  const res = await fetch(`${backendUrl}/rooms/${roomId}/members/${memberId}`, {
+    method: 'DELETE',
+    headers: { Authorization: `Bearer ${token}` },
+  });
+
+  if (!res.ok) {
+    const text = await res.text();
+    throw new Error(`メンバーの除外に失敗しました (${res.status}): ${text}`);
+  }
+}
+
 export async function deleteRoom(id: string, token: string): Promise<void> {
   const res = await fetch(`${backendUrl}/rooms/${id}`, {
     method: 'DELETE',


### PR DESCRIPTION
## Summary
- `DELETE /rooms/:id/members/:memberId` エンドポイントを追加（オーナーのみ）
- ルーム詳細画面のメンバー一覧に「退会させる」ボタンを追加（オーナー閲覧時のみ）
- 確認ダイアログ → API呼び出し → メンバー一覧から除去のフロー

## Test plan
- [ ] オーナーがメンバーを退会させられること（204 No Content）
- [ ] 非オーナーからの呼び出しが 403 Forbidden になること
- [ ] オーナー自身を対象にした呼び出しが 403 Forbidden になること
- [ ] 存在しないメンバーIDで 404 Not Found になること
- [ ] フロントエンドで「退会させる」ボタンがオーナー閲覧時のみ表示されること
- [ ] オーナー本人の行にはボタンが表示されないこと
- [ ] 確認ダイアログの「取消」で何も起こらないこと
- [ ] 除外成功後にメンバー一覧から該当メンバーが消えること

Closes #197

🤖 Generated with [Claude Code](https://claude.com/claude-code)