### PR TITLE
add: ルームダッシュボードにグラフ表示を追加 #198

### DIFF
--- a/apps/frontend/src/app/dashboard/page.tsx
+++ b/apps/frontend/src/app/dashboard/page.tsx
@@ -6,7 +6,6 @@ import { AppHeader } from '../../components/AppHeader';
 import { CategoryBarChart } from '../../components/CategoryBarChart';
 import { MonthlyBarChart } from '../../components/MonthlyBarChart';
 import { getMonthlySummary, getYearlySummary } from '../../lib/api/receipts';
-import { listRoomReceipts } from '../../lib/api/rooms';
 import { ReceiptUploadCard } from './_components/ReceiptUploadCard';
 
 function formatAmount(amount: number, currency: string): string {
@@ -40,53 +39,91 @@ export default async function DashboardPage() {
   const month = now.getMonth() + 1;
 
   if (currentRoom) {
-    // Roomモード: ルームのレシート一覧を表示
-    const receipts = await listRoomReceipts(currentRoom.id, session.backendToken).catch(() => []);
+    // Roomモード: 個人モードと同様のグラフ表示
+    const [roomMonthlySummary, roomYearlySummary] = await Promise.allSettled([
+      getMonthlySummary(session.backendToken, year, month, currentRoom.id),
+      getYearlySummary(session.backendToken, year, currentRoom.id),
+    ]);
+
+    const roomMonthly = roomMonthlySummary.status === 'fulfilled' ? roomMonthlySummary.value : null;
+    const roomYearly = roomYearlySummary.status === 'fulfilled' ? roomYearlySummary.value : null;
 
     return (
       <div className="min-h-screen bg-zinc-50 dark:bg-black">
         <AppHeader currentPath="/dashboard" />
 
         <main className="mx-auto max-w-5xl space-y-6 px-4 py-6 sm:px-6 sm:py-10">
-          <div className="rounded-2xl bg-white p-6 shadow-sm dark:bg-zinc-900">
-            <div className="mb-4 flex items-center justify-between">
-              <h2 className="text-base font-semibold text-zinc-900 dark:text-zinc-50">
-                {currentRoom.name} のレシート
-              </h2>
-              <Link
-                href="/receipts"
-                className="text-xs text-zinc-500 transition-colors hover:text-zinc-900 dark:text-zinc-400 dark:hover:text-zinc-50"
-              >
-                一覧 →
-              </Link>
+          {/* 上段: 今月・今年 */}
+          <div className="grid grid-cols-1 gap-6 sm:grid-cols-2">
+            {/* 今月の支出 */}
+            <div className="rounded-2xl bg-white p-6 shadow-sm dark:bg-zinc-900">
+              <div className="mb-4 flex items-center justify-between">
+                <h2 className="text-base font-semibold text-zinc-900 dark:text-zinc-50">
+                  {year}年{month}月の支出
+                </h2>
+                <Link
+                  href="/receipts"
+                  className="text-xs text-zinc-500 transition-colors hover:text-zinc-900 dark:text-zinc-400 dark:hover:text-zinc-50"
+                >
+                  一覧 →
+                </Link>
+              </div>
+
+              {roomMonthly ? (
+                <>
+                  <p className="mb-6 text-3xl font-bold tabular-nums text-zinc-900 dark:text-zinc-50">
+                    {formatAmount(roomMonthly.total, roomMonthly.currency)}
+                  </p>
+                  {roomMonthly.byCategory.length > 0 ? (
+                    <CategoryBarChart data={roomMonthly.byCategory} currency={roomMonthly.currency} />
+                  ) : (
+                    <p className="text-sm text-zinc-400 dark:text-zinc-600">
+                      今月の解析済みレシートがありません
+                    </p>
+                  )}
+                </>
+              ) : (
+                <p className="text-sm text-zinc-400 dark:text-zinc-600">データの取得に失敗しました</p>
+              )}
             </div>
 
-            {receipts.length === 0 ? (
-              <p className="text-sm text-zinc-400 dark:text-zinc-600">
-                レシートがまだありません
-              </p>
+            {/* 今年の支出 */}
+            <div className="rounded-2xl bg-white p-6 shadow-sm dark:bg-zinc-900">
+              <div className="mb-4 flex items-center justify-between">
+                <h2 className="text-base font-semibold text-zinc-900 dark:text-zinc-50">
+                  {year}年の支出
+                </h2>
+                {roomYearly && (
+                  <span className="text-xl font-bold tabular-nums text-zinc-900 dark:text-zinc-50">
+                    {formatAmount(roomYearly.total, roomYearly.currency)}
+                  </span>
+                )}
+              </div>
+
+              {roomYearly ? (
+                roomYearly.byCategory.length > 0 ? (
+                  <CategoryBarChart data={roomYearly.byCategory} currency={roomYearly.currency} />
+                ) : (
+                  <p className="text-sm text-zinc-400 dark:text-zinc-600">
+                    今年の解析済みレシートがありません
+                  </p>
+                )
+              ) : (
+                <p className="text-sm text-zinc-400 dark:text-zinc-600">データの取得に失敗しました</p>
+              )}
+            </div>
+          </div>
+
+          {/* 下段: 月別支出 */}
+          <div className="rounded-2xl bg-white p-6 shadow-sm dark:bg-zinc-900">
+            <h2 className="mb-6 text-base font-semibold text-zinc-900 dark:text-zinc-50">
+              {year}年 月別支出
+            </h2>
+
+            {roomYearly ? (
+              <MonthlyBarChart data={roomYearly.byMonthCategory} currency={roomYearly.currency} />
             ) : (
-              <ul className="divide-y divide-zinc-100 dark:divide-zinc-800">
-                {receipts.slice(0, 5).map((r) => (
-                  <li key={r.id} className="flex items-center justify-between py-3">
-                    <div className="min-w-0 flex-1">
-                      <p className="truncate text-sm text-zinc-900 dark:text-zinc-50">
-                        {r.storeName ?? r.originalFileName}
-                      </p>
-                      {r.uploaderDisplayName && (
-                        <p className="text-xs text-zinc-400 dark:text-zinc-600">
-                          {r.uploaderDisplayName}
-                        </p>
-                      )}
-                    </div>
-                    {r.total != null && r.currency && (
-                      <span className="ml-4 shrink-0 text-sm tabular-nums text-zinc-700 dark:text-zinc-300">
-                        {formatAmount(r.total, r.currency)}
-                      </span>
-                    )}
-                  </li>
-                ))}
-              </ul>
+              <p className="text-sm text-zinc-400 dark:text-zinc-600">データの取得に失敗しました</p>
             )}
           </div>
 

--- a/apps/frontend/src/lib/api/receipts.ts
+++ b/apps/frontend/src/lib/api/receipts.ts
@@ -64,8 +64,11 @@ export async function getMonthlySummary(
   token: string,
   year: number,
   month: number,
+  roomId?: string,
 ): Promise<MonthlySummaryResponse> {
-  const res = await fetch(`${backendUrl}/receipts/summary?year=${year}&month=${month}`, {
+  const params = new URLSearchParams({ year: String(year), month: String(month) });
+  if (roomId) params.set('roomId', roomId);
+  const res = await fetch(`${backendUrl}/receipts/summary?${params}`, {
     headers: { Authorization: `Bearer ${token}` },
   });
 
@@ -80,8 +83,11 @@ export async function getMonthlySummary(
 export async function getYearlySummary(
   token: string,
   year: number,
+  roomId?: string,
 ): Promise<YearlySummaryResponse> {
-  const res = await fetch(`${backendUrl}/receipts/yearly?year=${year}`, {
+  const params = new URLSearchParams({ year: String(year) });
+  if (roomId) params.set('roomId', roomId);
+  const res = await fetch(`${backendUrl}/receipts/yearly?${params}`, {
     headers: { Authorization: `Bearer ${token}` },
   });
 


### PR DESCRIPTION
## Summary
- ルームモードのダッシュボードからレシート一覧（最新5件）を削除
- 個人モードと同様のグラフ表示に差し替え（カテゴリ別円グラフ・月別棒グラフ）
- `getMonthlySummary` / `getYearlySummary` API ラッパーに `roomId` パラメータを追加
- `listRoomReceipts` のダッシュボードでのインポート・使用を廃止

## Test plan
- [ ] ルームモードのダッシュボードに今月の支出グラフ（カテゴリ別）が表示されること
- [ ] ルームモードのダッシュボードに今年の支出グラフ（カテゴリ別）が表示されること
- [ ] ルームモードのダッシュボードに年間月別棒グラフが表示されること
- [ ] レシート一覧（最新5件）が表示されないこと
- [ ] 個人モードのダッシュボードが従来通り正常に動作すること
- [ ] レシートが0件のルームでも適切なメッセージが表示されること

Closes #198

🤖 Generated with [Claude Code](https://claude.com/claude-code)