### PR TITLE
fix: レシート画像のEXIF Orientation自動回転を追加 #205

### DIFF
--- a/apps/backend/src/receipts/receipts.service.ts
+++ b/apps/backend/src/receipts/receipts.service.ts
@@ -81,6 +81,7 @@ export class ReceiptsService {
     buffer: Buffer,
   ): Promise<{ buffer: Buffer; mimeType: 'image/webp' }> {
     const converted = await sharp(buffer)
+      .rotate()
       .resize(1600, 1600, {
         fit: 'inside',            // 縦横比を保持・見切れなし
         withoutEnlargement: true, // 元画像より大きくしない


### PR DESCRIPTION
## Summary
- sharpパイプラインに `.rotate()` を追加し、EXIF Orientationに基づく自動回転を適用
- スマートフォンで撮影したレシート画像が正しい向きで表示・解析されるようになる

Closes #205

## Test plan
- [ ] スマートフォンで縦向きに撮影したレシート画像をアップロードし、正しい向きで表示されることを確認
- [ ] 既存のレシート画像が正しく表示されることを確認（リグレッションなし）

🤖 Generated with [Claude Code](https://claude.com/claude-code)