### PR TITLE
remove: ルームダッシュボードからReceiptUploadCardを削除 #207

### DIFF
--- a/apps/frontend/src/app/dashboard/page.tsx
+++ b/apps/frontend/src/app/dashboard/page.tsx
@@ -6,7 +6,7 @@ import { AppHeader } from '../../components/AppHeader';
 import { CategoryBarChart } from '../../components/CategoryBarChart';
 import { MonthlyBarChart } from '../../components/MonthlyBarChart';
 import { getMonthlySummary, getYearlySummary } from '../../lib/api/receipts';
-import { ReceiptUploadCard } from './_components/ReceiptUploadCard';
+
 
 function formatAmount(amount: number, currency: string): string {
   return new Intl.NumberFormat('ja-JP', {
@@ -127,7 +127,6 @@ export default async function DashboardPage() {
             )}
           </div>
 
-          <ReceiptUploadCard backendToken={session.backendToken} currentRoom={currentRoom} />
         </main>
       </div>
     );


### PR DESCRIPTION
## Summary
- ルームモードのダッシュボードから `ReceiptUploadCard` の表示を削除
- `/receipts` ページに同じコンポーネントがあり導線が重複していたため整理

Closes #207

## Test plan
- [ ] ルームモードでダッシュボードにアクセスし、ReceiptUploadCardが表示されないことを確認
- [ ] 個人モードのダッシュボードに影響がないことを確認
- [ ] `/receipts` ページでレシートアップロードが引き続き利用できることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)