### PR TITLE
add: チャットサイドバーの開閉トグル機能を実装 #206

### DIFF
--- a/apps/frontend/src/app/chat/_components/ChatContainer.tsx
+++ b/apps/frontend/src/app/chat/_components/ChatContainer.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useRef } from 'react';
+import { useEffect, useRef, useState } from 'react';
 import { SessionSidebar } from './SessionSidebar';
 import { MessageThread } from './MessageThread';
 
@@ -10,8 +10,14 @@ interface ChatContainerProps {
 }
 
 export function ChatContainer({ backendToken, sessionId }: ChatContainerProps) {
-  // MessageThread からメッセージ送信完了を受け取り、SessionSidebar のセッション一覧を再取得する
   const refreshSessionsRef = useRef<(() => void) | null>(null);
+  const [sidebarOpen, setSidebarOpen] = useState(true);
+
+  // sm未満ではデフォルトで閉じる
+  useEffect(() => {
+    const mq = window.matchMedia('(min-width: 640px)');
+    setSidebarOpen(mq.matches);
+  }, []);
 
   const handleSessionsRefresh = (refresh: () => void) => {
     refreshSessionsRef.current = refresh;
@@ -27,9 +33,10 @@ export function ChatContainer({ backendToken, sessionId }: ChatContainerProps) {
         backendToken={backendToken}
         currentSessionId={sessionId}
         onSessionsRefresh={handleSessionsRefresh}
+        isOpen={sidebarOpen}
+        onToggle={() => setSidebarOpen((prev) => !prev)}
       />
       {sessionId ? (
-        // key でセッション切り替え時に再マウントし状態をリセットする
         <MessageThread
           key={sessionId}
           backendToken={backendToken}
@@ -39,7 +46,7 @@ export function ChatContainer({ backendToken, sessionId }: ChatContainerProps) {
       ) : (
         <div className="flex flex-1 items-center justify-center">
           <p className="text-sm text-zinc-400 dark:text-zinc-500">
-            左のサイドバーからチャットを選択するか、新規チャットを開始してください
+            サイドバーからチャットを選択するか、新規チャットを開始してください
           </p>
         </div>
       )}

--- a/apps/frontend/src/app/chat/_components/ChatContainer.tsx
+++ b/apps/frontend/src/app/chat/_components/ChatContainer.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useEffect, useRef, useState } from 'react';
+import { useRef, useState } from 'react';
 import { SessionSidebar } from './SessionSidebar';
 import { MessageThread } from './MessageThread';
 
@@ -11,13 +11,9 @@ interface ChatContainerProps {
 
 export function ChatContainer({ backendToken, sessionId }: ChatContainerProps) {
   const refreshSessionsRef = useRef<(() => void) | null>(null);
-  const [sidebarOpen, setSidebarOpen] = useState(true);
-
-  // sm未満ではデフォルトで閉じる
-  useEffect(() => {
-    const mq = window.matchMedia('(min-width: 640px)');
-    setSidebarOpen(mq.matches);
-  }, []);
+  const [sidebarOpen, setSidebarOpen] = useState(
+    () => typeof window !== 'undefined' && window.matchMedia('(min-width: 640px)').matches,
+  );
 
   const handleSessionsRefresh = (refresh: () => void) => {
     refreshSessionsRef.current = refresh;

--- a/apps/frontend/src/app/chat/_components/SessionSidebar.tsx
+++ b/apps/frontend/src/app/chat/_components/SessionSidebar.tsx
@@ -14,12 +14,16 @@ interface SessionSidebarProps {
   backendToken: string;
   currentSessionId: string | null;
   onSessionsRefresh?: (refresh: () => void) => void;
+  isOpen: boolean;
+  onToggle: () => void;
 }
 
 export function SessionSidebar({
   backendToken,
   currentSessionId,
   onSessionsRefresh,
+  isOpen,
+  onToggle,
 }: SessionSidebarProps) {
   const router = useRouter();
   const [sidebarState, setSidebarState] = useState<SidebarState>({ status: 'loading' });
@@ -39,7 +43,6 @@ export function SessionSidebar({
     loadSessions();
   }, [loadSessions]);
 
-  // 親から再取得トリガーを受け取れるようにする
   useEffect(() => {
     onSessionsRefresh?.(loadSessions);
   }, [onSessionsRefresh, loadSessions]);
@@ -62,59 +65,87 @@ export function SessionSidebar({
   };
 
   return (
-    <aside className="flex w-64 flex-col border-r border-zinc-200 bg-white dark:border-zinc-800 dark:bg-zinc-900">
-      <div className="flex items-center justify-between border-b border-zinc-200 px-4 py-4 dark:border-zinc-800">
-        <span className="text-sm font-semibold text-zinc-900 dark:text-zinc-50">チャット履歴</span>
-        <button
-          onClick={handleNewChat}
-          disabled={creating}
-          className="rounded-full bg-zinc-900 px-3 py-1 text-xs font-medium text-white transition-colors hover:bg-zinc-700 disabled:opacity-50 dark:bg-zinc-50 dark:text-zinc-900 dark:hover:bg-zinc-200"
-        >
-          {creating ? '作成中...' : '+ 新規'}
-        </button>
-      </div>
+    <div className="relative flex shrink-0">
+      <aside
+        className={`flex flex-col border-r border-zinc-200 bg-white transition-[width] duration-200 ease-in-out dark:border-zinc-800 dark:bg-zinc-900 ${
+          isOpen ? 'w-64' : 'w-0'
+        } overflow-hidden`}
+      >
+        <div className="flex w-64 items-center justify-between border-b border-zinc-200 px-4 py-4 dark:border-zinc-800">
+          <span className="text-sm font-semibold text-zinc-900 dark:text-zinc-50">チャット履歴</span>
+          <button
+            onClick={handleNewChat}
+            disabled={creating}
+            className="rounded-full bg-zinc-900 px-3 py-1 text-xs font-medium text-white transition-colors hover:bg-zinc-700 disabled:opacity-50 dark:bg-zinc-50 dark:text-zinc-900 dark:hover:bg-zinc-200"
+          >
+            {creating ? '作成中...' : '+ 新規'}
+          </button>
+        </div>
 
-      <div className="flex-1 overflow-y-auto py-2">
-        {sidebarState.status === 'loading' && (
-          <p className="px-4 py-4 text-xs text-zinc-400 dark:text-zinc-500">読み込み中...</p>
-        )}
-        {sidebarState.status === 'error' && (
-          <div className="px-4 py-4">
-            <p className="text-xs text-red-500">取得に失敗しました</p>
-            <button
-              onClick={loadSessions}
-              className="mt-2 text-xs text-zinc-500 underline hover:text-zinc-700 dark:hover:text-zinc-300"
-            >
-              再試行
-            </button>
-          </div>
-        )}
-        {sidebarState.status === 'ready' && sidebarState.sessions.length === 0 && (
-          <p className="px-4 py-4 text-xs text-zinc-400 dark:text-zinc-500">
-            チャット履歴がありません
-          </p>
-        )}
-        {sidebarState.status === 'ready' &&
-          sidebarState.sessions.map((session) => {
-            const isActive = session.id === currentSessionId;
-            return (
+        <div className="w-64 flex-1 overflow-y-auto py-2">
+          {sidebarState.status === 'loading' && (
+            <p className="px-4 py-4 text-xs text-zinc-400 dark:text-zinc-500">読み込み中...</p>
+          )}
+          {sidebarState.status === 'error' && (
+            <div className="px-4 py-4">
+              <p className="text-xs text-red-500">取得に失敗しました</p>
               <button
-                key={session.id}
-                onClick={() => handleSelectSession(session.id)}
-                className={`w-full px-4 py-3 text-left transition-colors hover:bg-zinc-100 dark:hover:bg-zinc-800 ${
-                  isActive ? 'bg-zinc-100 dark:bg-zinc-800' : ''
-                }`}
+                onClick={loadSessions}
+                className="mt-2 text-xs text-zinc-500 underline hover:text-zinc-700 dark:hover:text-zinc-300"
               >
-                <p className="truncate text-sm font-medium text-zinc-900 dark:text-zinc-50">
-                  {session.title ?? '無題のチャット'}
-                </p>
-                <p className="mt-0.5 text-xs text-zinc-400 dark:text-zinc-500">
-                  {new Date(session.createdAt).toLocaleDateString('ja-JP')}
-                </p>
+                再試行
               </button>
-            );
-          })}
-      </div>
-    </aside>
+            </div>
+          )}
+          {sidebarState.status === 'ready' && sidebarState.sessions.length === 0 && (
+            <p className="px-4 py-4 text-xs text-zinc-400 dark:text-zinc-500">
+              チャット履歴がありません
+            </p>
+          )}
+          {sidebarState.status === 'ready' &&
+            sidebarState.sessions.map((session) => {
+              const isActive = session.id === currentSessionId;
+              return (
+                <button
+                  key={session.id}
+                  onClick={() => handleSelectSession(session.id)}
+                  className={`w-full px-4 py-3 text-left transition-colors hover:bg-zinc-100 dark:hover:bg-zinc-800 ${
+                    isActive ? 'bg-zinc-100 dark:bg-zinc-800' : ''
+                  }`}
+                >
+                  <p className="truncate text-sm font-medium text-zinc-900 dark:text-zinc-50">
+                    {session.title ?? '無題のチャット'}
+                  </p>
+                  <p className="mt-0.5 text-xs text-zinc-400 dark:text-zinc-500">
+                    {new Date(session.createdAt).toLocaleDateString('ja-JP')}
+                  </p>
+                </button>
+              );
+            })}
+        </div>
+      </aside>
+
+      {/* トグルボタン: サイドバーの右端に配置 */}
+      <button
+        onClick={onToggle}
+        className="flex h-8 w-8 items-center justify-center self-start mt-3 -ml-1 rounded-r-md border border-l-0 border-zinc-200 bg-white text-zinc-500 transition-colors hover:bg-zinc-50 hover:text-zinc-900 dark:border-zinc-800 dark:bg-zinc-900 dark:text-zinc-400 dark:hover:bg-zinc-800 dark:hover:text-zinc-50"
+        aria-label={isOpen ? 'サイドバーを閉じる' : 'サイドバーを開く'}
+      >
+        <svg
+          xmlns="http://www.w3.org/2000/svg"
+          width="16"
+          height="16"
+          viewBox="0 0 24 24"
+          fill="none"
+          stroke="currentColor"
+          strokeWidth="2"
+          strokeLinecap="round"
+          strokeLinejoin="round"
+          className={`transition-transform duration-200 ${isOpen ? '' : 'rotate-180'}`}
+        >
+          <polyline points="15 18 9 12 15 6" />
+        </svg>
+      </button>
+    </div>
   );
 }


### PR DESCRIPTION
## Summary
- サイドバーの開閉トグルボタンを追加（chevronアイコンで開閉状態を表示）
- 閉じた状態ではメッセージエリアが画面幅いっぱいに広がる
- モバイル（sm未満）ではデフォルトで閉じた状態
- 開閉時にwidthトランジションアニメーションを実装

Closes #206

## Test plan
- [ ] デスクトップでサイドバーが初期表示されていることを確認
- [ ] トグルボタンでサイドバーを閉じ/開きできることを確認
- [ ] 閉じた状態でメッセージエリアが全幅に広がることを確認
- [ ] モバイル幅でアクセスし、サイドバーがデフォルトで閉じていることを確認
- [ ] 開閉時にスムーズなアニメーションがあることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)