### PR TITLE
add: スマホ表示時にヘッダーナビをアイコン表示にする #208

### DIFF
--- a/apps/frontend/package-lock.json
+++ b/apps/frontend/package-lock.json
@@ -8,6 +8,7 @@
       "name": "frontend",
       "version": "0.1.0",
       "dependencies": {
+        "lucide-react": "^1.8.0",
         "next": "16.2.1",
         "next-auth": "^5.0.0-beta.30",
         "react": "19.2.4",
@@ -5222,6 +5223,15 @@
       "license": "ISC",
       "dependencies": {
         "yallist": "^3.0.2"
+      }
+    },
+    "node_modules/lucide-react": {
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/lucide-react/-/lucide-react-1.8.0.tgz",
+      "integrity": "sha512-WuvlsjngSk7TnTBJ1hsCy3ql9V9VOdcPkd3PKcSmM34vJD8KG6molxz7m7zbYFgICwsanQWmJ13JlYs4Zp7Arw==",
+      "license": "ISC",
+      "peerDependencies": {
+        "react": "^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0"
       }
     },
     "node_modules/magic-string": {

--- a/apps/frontend/package.json
+++ b/apps/frontend/package.json
@@ -10,6 +10,7 @@
     "type-check": "tsc --noEmit"
   },
   "dependencies": {
+    "lucide-react": "^1.8.0",
     "next": "16.2.1",
     "next-auth": "^5.0.0-beta.30",
     "react": "19.2.4",

--- a/apps/frontend/src/components/AppHeader.tsx
+++ b/apps/frontend/src/components/AppHeader.tsx
@@ -1,4 +1,5 @@
 import Link from 'next/link';
+import { ChartColumnIncreasing, Receipt, MessageSquareText, LogOut } from 'lucide-react';
 import { signOut } from '../../auth';
 import { ExitButton } from './ExitButton';
 import { RoomSettingsNavLink } from './RoomSettingsNavLink';
@@ -11,7 +12,6 @@ export function AppHeader({ currentPath }: AppHeaderProps) {
   return (
     <header className="border-b border-zinc-200 bg-white dark:border-zinc-800 dark:bg-zinc-900">
       <div className="mx-auto max-w-4xl px-4 sm:px-6">
-        {/* スマホ: ロゴとログアウトを上段、ナビを下段。PC: 全て横並び */}
         <div className="flex items-start justify-between py-3 sm:items-center sm:py-4">
           <div className="flex flex-col gap-2 sm:flex-row sm:items-center sm:gap-6">
             <Link
@@ -29,7 +29,8 @@ export function AppHeader({ currentPath }: AppHeaderProps) {
                     : 'text-zinc-500 hover:text-zinc-900 dark:text-zinc-400 dark:hover:text-zinc-50'
                 }`}
               >
-                ダッシュボード
+                <ChartColumnIncreasing size={18} className="sm:hidden" />
+                <span className="hidden sm:inline">ダッシュボード</span>
               </Link>
               <Link
                 href="/receipts"
@@ -39,7 +40,8 @@ export function AppHeader({ currentPath }: AppHeaderProps) {
                     : 'text-zinc-500 hover:text-zinc-900 dark:text-zinc-400 dark:hover:text-zinc-50'
                 }`}
               >
-                レシート
+                <Receipt size={18} className="sm:hidden" />
+                <span className="hidden sm:inline">レシート</span>
               </Link>
               <Link
                 href="/chat"
@@ -49,7 +51,8 @@ export function AppHeader({ currentPath }: AppHeaderProps) {
                     : 'text-zinc-500 hover:text-zinc-900 dark:text-zinc-400 dark:hover:text-zinc-50'
                 }`}
               >
-                チャット
+                <MessageSquareText size={18} className="sm:hidden" />
+                <span className="hidden sm:inline">チャット</span>
               </Link>
               <RoomSettingsNavLink />
             </nav>
@@ -66,7 +69,8 @@ export function AppHeader({ currentPath }: AppHeaderProps) {
                 type="submit"
                 className="shrink-0 pt-0.5 text-sm text-zinc-500 transition-colors hover:text-zinc-900 sm:pt-0 dark:text-zinc-400 dark:hover:text-zinc-50"
               >
-                ログアウト
+                <LogOut size={18} className="sm:hidden" />
+                <span className="hidden sm:inline">ログアウト</span>
               </button>
             </form>
           </div>

--- a/apps/frontend/src/components/ExitButton.tsx
+++ b/apps/frontend/src/components/ExitButton.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import { useRouter } from 'next/navigation';
+import { Signpost } from 'lucide-react';
 import { useMode } from '../contexts/ModeContext';
 
 export function ExitButton() {
@@ -17,7 +18,8 @@ export function ExitButton() {
       onClick={handleExit}
       className="shrink-0 pt-0.5 text-sm text-zinc-500 transition-colors hover:text-zinc-900 sm:pt-0 dark:text-zinc-400 dark:hover:text-zinc-50"
     >
-      退出
+      <Signpost size={18} className="sm:hidden" />
+      <span className="hidden sm:inline">退出</span>
     </button>
   );
 }

--- a/apps/frontend/src/components/RoomSettingsNavLink.tsx
+++ b/apps/frontend/src/components/RoomSettingsNavLink.tsx
@@ -2,6 +2,7 @@
 
 import Link from 'next/link';
 import { usePathname } from 'next/navigation';
+import { Cog } from 'lucide-react';
 import { useMode } from '../contexts/ModeContext';
 
 export function RoomSettingsNavLink() {
@@ -22,7 +23,8 @@ export function RoomSettingsNavLink() {
           : 'text-zinc-500 hover:text-zinc-900 dark:text-zinc-400 dark:hover:text-zinc-50'
       }`}
     >
-      ルーム設定
+      <Cog size={18} className="sm:hidden" />
+      <span className="hidden sm:inline">ルーム設定</span>
     </Link>
   );
 }


### PR DESCRIPTION
## Summary
- `lucide-react` を導入し、各ナビ項目にアイコンを追加
- スマホ（sm未満）ではアイコンのみ表示、デスクトップ（sm以上）ではテキスト表示を維持
- アイコン割り当て: ダッシュボード→ChartColumnIncreasing、レシート→Receipt、チャット→MessageSquareText、ルーム設定→Cog、退出→Signpost、ログアウト→LogOut

Closes #208

## Test plan
- [ ] スマホ幅でアイコンのみ表示されることを確認
- [ ] デスクトップ幅でテキスト表示が従来通りであることを確認
- [ ] ルームモードでルーム設定アイコンが表示されることを確認
- [ ] 退出・ログアウトボタンもアイコン表示になることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)