### PR TITLE
fix: スマホ表示時のヘッダーアイコンを均等配置し高さずれを修正 #214

### DIFF
--- a/apps/frontend/src/components/AppHeader.tsx
+++ b/apps/frontend/src/components/AppHeader.tsx
@@ -9,18 +9,23 @@ interface AppHeaderProps {
 }
 
 export function AppHeader({ currentPath }: AppHeaderProps) {
+  const handleSignOut = async () => {
+    'use server';
+    await signOut({ redirectTo: '/' });
+  };
+
   return (
     <header className="border-b border-zinc-200 bg-white dark:border-zinc-800 dark:bg-zinc-900">
       <div className="mx-auto max-w-4xl px-4 sm:px-6">
         <div className="flex items-start justify-between py-3 sm:items-center sm:py-4">
-          <div className="flex flex-col gap-2 sm:flex-row sm:items-center sm:gap-6">
+          <div className="flex w-full flex-col gap-2 sm:w-auto sm:flex-row sm:items-center sm:gap-6">
             <Link
               href="/dashboard"
               className="text-lg font-semibold text-zinc-900 dark:text-zinc-50"
             >
               Credit Checker
             </Link>
-            <nav className="flex items-center gap-4">
+            <nav className="flex items-center justify-evenly sm:justify-normal sm:gap-4">
               <Link
                 href="/dashboard"
                 className={`text-sm transition-colors ${
@@ -55,22 +60,27 @@ export function AppHeader({ currentPath }: AppHeaderProps) {
                 <span className="hidden sm:inline">チャット</span>
               </Link>
               <RoomSettingsNavLink />
+              <div className="sm:hidden">
+                <ExitButton />
+              </div>
+              <form action={handleSignOut} className="sm:hidden">
+                <button
+                  type="submit"
+                  className="text-sm text-zinc-500 transition-colors hover:text-zinc-900 dark:text-zinc-400 dark:hover:text-zinc-50"
+                >
+                  <LogOut size={18} />
+                </button>
+              </form>
             </nav>
           </div>
-          <div className="flex items-center gap-4">
+          <div className="hidden items-center gap-4 sm:flex">
             <ExitButton />
-            <form
-              action={async () => {
-                'use server';
-                await signOut({ redirectTo: '/' });
-              }}
-            >
+            <form action={handleSignOut}>
               <button
                 type="submit"
-                className="shrink-0 pt-0.5 text-sm text-zinc-500 transition-colors hover:text-zinc-900 sm:pt-0 dark:text-zinc-400 dark:hover:text-zinc-50"
+                className="shrink-0 text-sm text-zinc-500 transition-colors hover:text-zinc-900 dark:text-zinc-400 dark:hover:text-zinc-50"
               >
-                <LogOut size={18} className="sm:hidden" />
-                <span className="hidden sm:inline">ログアウト</span>
+                ログアウト
               </button>
             </form>
           </div>

--- a/apps/frontend/src/components/ExitButton.tsx
+++ b/apps/frontend/src/components/ExitButton.tsx
@@ -16,7 +16,7 @@ export function ExitButton() {
   return (
     <button
       onClick={handleExit}
-      className="shrink-0 pt-0.5 text-sm text-zinc-500 transition-colors hover:text-zinc-900 sm:pt-0 dark:text-zinc-400 dark:hover:text-zinc-50"
+      className="shrink-0 text-sm text-zinc-500 transition-colors hover:text-zinc-900 dark:text-zinc-400 dark:hover:text-zinc-50"
     >
       <Signpost size={18} className="sm:hidden" />
       <span className="hidden sm:inline">退出</span>


### PR DESCRIPTION
## Summary
- スマホ表示時、全アイコン（ダッシュボード、レシート、チャット、ルーム設定、退出、ログアウト）を `justify-evenly` で横幅いっぱいに均等配置
- ExitButton・ログアウトボタンの `pt-0.5` を削除し、`items-center` で全アイコンの垂直位置を統一
- デスクトップ表示は従来のレイアウトを維持（nav + actions の分離構造）

Closes #214

## Test plan
- [ ] スマホ表示（< 640px）でヘッダーの全アイコンが均等配置されていること
- [ ] 全アイコンの垂直位置が揃っていること
- [ ] ルーム選択時にルーム設定アイコンが追加表示されても均等配置が維持されること
- [ ] デスクトップ表示（≥ 640px）でレイアウトが従来通りであること

🤖 Generated with [Claude Code](https://claude.com/claude-code)