### PR TITLE
fix: モバイルブラウザのアドレスバーを考慮した画面高さに修正 #217

### DIFF
--- a/apps/frontend/src/app/chat/page.tsx
+++ b/apps/frontend/src/app/chat/page.tsx
@@ -17,7 +17,7 @@ export default async function ChatPage({
   const { session: sessionId } = await searchParams;
 
   return (
-    <div className="flex h-screen flex-col bg-zinc-50 dark:bg-black">
+    <div className="flex h-dvh flex-col bg-zinc-50 dark:bg-black">
       <AppHeader currentPath="/chat" />
 
       <main className="flex flex-1 overflow-hidden">

--- a/apps/frontend/src/app/dashboard/page.tsx
+++ b/apps/frontend/src/app/dashboard/page.tsx
@@ -49,7 +49,7 @@ export default async function DashboardPage() {
     const roomYearly = roomYearlySummary.status === 'fulfilled' ? roomYearlySummary.value : null;
 
     return (
-      <div className="min-h-screen bg-zinc-50 dark:bg-black">
+      <div className="min-h-dvh bg-zinc-50 dark:bg-black">
         <AppHeader currentPath="/dashboard" />
 
         <main className="mx-auto max-w-5xl space-y-6 px-4 py-6 sm:px-6 sm:py-10">
@@ -142,7 +142,7 @@ export default async function DashboardPage() {
   const yearly = yearlySummary.status === 'fulfilled' ? yearlySummary.value : null;
 
   return (
-    <div className="min-h-screen bg-zinc-50 dark:bg-black">
+    <div className="min-h-dvh bg-zinc-50 dark:bg-black">
       <AppHeader currentPath="/dashboard" />
 
       <main className="mx-auto max-w-5xl space-y-6 px-4 py-6 sm:px-6 sm:py-10">

--- a/apps/frontend/src/app/receipts/[id]/duplicates/page.tsx
+++ b/apps/frontend/src/app/receipts/[id]/duplicates/page.tsx
@@ -40,7 +40,7 @@ export default async function DuplicateCheckPage({
   ]);
 
   return (
-    <div className="min-h-screen bg-zinc-50 dark:bg-black">
+    <div className="min-h-dvh bg-zinc-50 dark:bg-black">
       <AppHeader currentPath="/receipts" />
 
       <main className="mx-auto max-w-7xl space-y-6 px-6 py-10">

--- a/apps/frontend/src/app/receipts/[id]/page.tsx
+++ b/apps/frontend/src/app/receipts/[id]/page.tsx
@@ -23,7 +23,7 @@ export default async function ReceiptDetailPage({ params }: ReceiptDetailPagePro
   ]);
 
   return (
-    <div className="min-h-screen bg-zinc-50 dark:bg-black">
+    <div className="min-h-dvh bg-zinc-50 dark:bg-black">
       <AppHeader currentPath="/receipts" />
 
       <main className="mx-auto max-w-4xl space-y-6 px-4 py-6 sm:px-6 sm:py-10">

--- a/apps/frontend/src/app/receipts/page.tsx
+++ b/apps/frontend/src/app/receipts/page.tsx
@@ -54,7 +54,7 @@ export default async function ReceiptsPage() {
         .catch(() => [] as ListReceiptItem[]));
 
   return (
-    <div className="min-h-screen bg-zinc-50 dark:bg-black">
+    <div className="min-h-dvh bg-zinc-50 dark:bg-black">
       <AppHeader currentPath="/receipts" />
 
       <main className="mx-auto max-w-4xl space-y-6 px-4 py-6 sm:px-6 sm:py-10">

--- a/apps/frontend/src/app/rooms/[id]/page.tsx
+++ b/apps/frontend/src/app/rooms/[id]/page.tsx
@@ -30,7 +30,7 @@ export default async function RoomDetailPage({ params }: RoomDetailPageProps) {
   const isOwner = room.ownerId === jwtPayload.sub;
 
   return (
-    <div className="min-h-screen bg-zinc-50 dark:bg-black">
+    <div className="min-h-dvh bg-zinc-50 dark:bg-black">
       <AppHeader currentPath={`/rooms/${id}`} />
       <main className="mx-auto max-w-4xl space-y-6 px-4 py-6">
 

--- a/apps/frontend/src/app/rooms/join/page.tsx
+++ b/apps/frontend/src/app/rooms/join/page.tsx
@@ -14,7 +14,7 @@ export default async function JoinRoomPage({ searchParams }: JoinRoomPageProps) 
   // トークンが欠けているケース
   if (!token) {
     return (
-      <div className="min-h-screen bg-zinc-50 dark:bg-black">
+      <div className="min-h-dvh bg-zinc-50 dark:bg-black">
         <AppHeader currentPath="/rooms/join" />
         <main className="mx-auto max-w-md space-y-4 px-4 py-10">
           <div className="rounded-2xl bg-white p-6 shadow-sm dark:bg-zinc-900">
@@ -45,7 +45,7 @@ export default async function JoinRoomPage({ searchParams }: JoinRoomPageProps) 
     };
 
     return (
-      <div className="min-h-screen bg-zinc-50 dark:bg-black">
+      <div className="min-h-dvh bg-zinc-50 dark:bg-black">
         <AppHeader currentPath="/rooms/join" />
         <main className="mx-auto max-w-md space-y-4 px-4 py-10">
           <div className="rounded-2xl bg-white p-6 shadow-sm dark:bg-zinc-900">
@@ -70,7 +70,7 @@ export default async function JoinRoomPage({ searchParams }: JoinRoomPageProps) 
   }
 
   return (
-    <div className="min-h-screen bg-zinc-50 dark:bg-black">
+    <div className="min-h-dvh bg-zinc-50 dark:bg-black">
       <AppHeader currentPath="/rooms/join" />
       <main className="mx-auto max-w-md space-y-4 px-4 py-10">
         <div className="rounded-2xl bg-white p-6 shadow-sm dark:bg-zinc-900">


### PR DESCRIPTION
## Summary
- モバイルブラウザでアドレスバー分のコンテンツはみ出しが発生する問題を修正
- `h-screen`（100vh）→ `h-dvh`（100dvh）、`min-h-screen` → `min-h-dvh` に置換
- 対象: chat, dashboard, receipts, receipts/[id], receipts/[id]/duplicates, rooms/[id], rooms/join の全7ファイル

Closes #217

## Test plan
- [ ] モバイルブラウザ（Chrome, Safari）でチャット画面の入力フォームが画面内に収まることを確認
- [ ] 各ページで背景が途切れないことを確認
- [ ] デスクトップブラウザで表示崩れがないことを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)