### PR TITLE
チャットセッションの削除・タイトル編集機能 #219

### DIFF
--- a/apps/backend/src/chat/chat.controller.ts
+++ b/apps/backend/src/chat/chat.controller.ts
@@ -1,9 +1,12 @@
 import {
   Body,
   Controller,
+  Delete,
   Get,
+  HttpCode,
   Param,
   ParseUUIDPipe,
+  Patch,
   Post,
   UseGuards,
 } from '@nestjs/common';
@@ -16,6 +19,8 @@ import { ListMessagesResponseDto } from './dto/list-messages.response.dto';
 import { ListSessionsResponseDto } from './dto/list-sessions.response.dto';
 import { SendMessageRequestDto } from './dto/send-message.request.dto';
 import { SendMessageResponseDto } from './dto/send-message.response.dto';
+import { UpdateSessionRequestDto } from './dto/update-session.request.dto';
+import { UpdateSessionResponseDto } from './dto/update-session.response.dto';
 import { MessageRole } from '../entities/chat-message.entity';
 
 @Controller('chat')
@@ -47,6 +52,33 @@ export class ChatController {
         createdAt: s.createdAt,
       })),
     };
+  }
+
+  @Patch('sessions/:id')
+  async updateSession(
+    @CurrentUser() user: User,
+    @Param('id', ParseUUIDPipe) id: string,
+    @Body() body: UpdateSessionRequestDto,
+  ): Promise<UpdateSessionResponseDto> {
+    const session = await this.chatService.updateSessionTitle(
+      id,
+      user.id,
+      body.title,
+    );
+    return {
+      id: session.id,
+      title: session.title ?? '',
+      createdAt: session.createdAt,
+    };
+  }
+
+  @Delete('sessions/:id')
+  @HttpCode(204)
+  async deleteSession(
+    @CurrentUser() user: User,
+    @Param('id', ParseUUIDPipe) id: string,
+  ): Promise<void> {
+    await this.chatService.deleteSession(id, user.id);
   }
 
   @Get('sessions/:id/messages')

--- a/apps/backend/src/chat/chat.service.ts
+++ b/apps/backend/src/chat/chat.service.ts
@@ -59,6 +59,21 @@ export class ChatService {
     });
   }
 
+  async updateSessionTitle(
+    sessionId: string,
+    userId: string,
+    title: string,
+  ): Promise<ChatSession> {
+    const session = await this.findSessionOrThrow(sessionId, userId);
+    session.title = title;
+    return this.sessionsRepository.save(session);
+  }
+
+  async deleteSession(sessionId: string, userId: string): Promise<void> {
+    const session = await this.findSessionOrThrow(sessionId, userId);
+    await this.sessionsRepository.remove(session);
+  }
+
   async getMessages(sessionId: string, userId: string): Promise<ChatMessage[]> {
     const session = await this.findSessionOrThrow(sessionId, userId);
     return this.messagesRepository.find({

--- a/apps/backend/src/chat/dto/update-session.request.dto.ts
+++ b/apps/backend/src/chat/dto/update-session.request.dto.ts
@@ -1,0 +1,3 @@
+export class UpdateSessionRequestDto {
+  title: string;
+}

--- a/apps/backend/src/chat/dto/update-session.response.dto.ts
+++ b/apps/backend/src/chat/dto/update-session.response.dto.ts
@@ -1,0 +1,5 @@
+export interface UpdateSessionResponseDto {
+  id: string;
+  title: string;
+  createdAt: Date;
+}

--- a/apps/frontend/src/app/chat/_components/SessionSidebar.tsx
+++ b/apps/frontend/src/app/chat/_components/SessionSidebar.tsx
@@ -1,8 +1,13 @@
 'use client';
 
-import { useCallback, useEffect, useState } from 'react';
+import { useCallback, useEffect, useRef, useState } from 'react';
 import { useRouter } from 'next/navigation';
-import { createChatSession, getChatSessions } from '../../../lib/api/chat';
+import {
+  createChatSession,
+  getChatSessions,
+  updateChatSession,
+  deleteChatSession,
+} from '../../../lib/api/chat';
 import { ChatSession } from '../../../types/chat';
 
 type SidebarState =
@@ -29,6 +34,17 @@ export function SessionSidebar({
   const [sidebarState, setSidebarState] = useState<SidebarState>({ status: 'loading' });
   const [creating, setCreating] = useState(false);
 
+  // アクションメニュー展開中のセッションID
+  const [menuOpenId, setMenuOpenId] = useState<string | null>(null);
+  // インライン編集中のセッションID
+  const [editingId, setEditingId] = useState<string | null>(null);
+  const [editTitle, setEditTitle] = useState('');
+  // 削除確認ダイアログのセッションID
+  const [deleteConfirmId, setDeleteConfirmId] = useState<string | null>(null);
+  const [deleting, setDeleting] = useState(false);
+
+  const menuRef = useRef<HTMLDivElement>(null);
+
   const loadSessions = useCallback(async () => {
     setSidebarState({ status: 'loading' });
     try {
@@ -47,6 +63,18 @@ export function SessionSidebar({
     onSessionsRefresh?.(loadSessions);
   }, [onSessionsRefresh, loadSessions]);
 
+  // メニュー外クリックで閉じる
+  useEffect(() => {
+    if (!menuOpenId) return;
+    const handleClick = (e: MouseEvent) => {
+      if (menuRef.current && !menuRef.current.contains(e.target as Node)) {
+        setMenuOpenId(null);
+      }
+    };
+    document.addEventListener('mousedown', handleClick);
+    return () => document.removeEventListener('mousedown', handleClick);
+  }, [menuOpenId]);
+
   const handleNewChat = async () => {
     setCreating(true);
     try {
@@ -61,17 +89,82 @@ export function SessionSidebar({
   };
 
   const handleSelectSession = (sessionId: string) => {
+    if (editingId || deleteConfirmId) return;
     router.push(`/chat?session=${sessionId}`);
+  };
+
+  const handleMenuToggle = (e: React.MouseEvent, sessionId: string) => {
+    e.stopPropagation();
+    setMenuOpenId((prev) => (prev === sessionId ? null : sessionId));
+  };
+
+  const handleStartEdit = (session: ChatSession) => {
+    setMenuOpenId(null);
+    setEditingId(session.id);
+    setEditTitle(session.title ?? '');
+  };
+
+  const handleCancelEdit = () => {
+    setEditingId(null);
+    setEditTitle('');
+  };
+
+  const handleSaveEdit = async (sessionId: string) => {
+    const trimmed = editTitle.trim();
+    if (!trimmed) return;
+    try {
+      await updateChatSession(sessionId, trimmed, backendToken);
+      setEditingId(null);
+      setEditTitle('');
+      await loadSessions();
+    } catch {
+      // 失敗時はそのまま
+    }
+  };
+
+  const handleEditKeyDown = (e: React.KeyboardEvent, sessionId: string) => {
+    if (e.key === 'Enter') {
+      e.preventDefault();
+      handleSaveEdit(sessionId);
+    } else if (e.key === 'Escape') {
+      handleCancelEdit();
+    }
+  };
+
+  const handleStartDelete = (sessionId: string) => {
+    setMenuOpenId(null);
+    setDeleteConfirmId(sessionId);
+  };
+
+  const handleConfirmDelete = async () => {
+    if (!deleteConfirmId) return;
+    setDeleting(true);
+    try {
+      await deleteChatSession(deleteConfirmId, backendToken);
+      if (deleteConfirmId === currentSessionId) {
+        router.push('/chat');
+      }
+      setDeleteConfirmId(null);
+      await loadSessions();
+    } catch {
+      // 失敗時はそのまま
+    } finally {
+      setDeleting(false);
+    }
+  };
+
+  const handleCancelDelete = () => {
+    setDeleteConfirmId(null);
   };
 
   return (
     <div className="relative flex shrink-0">
       <aside
         className={`flex flex-col border-r border-zinc-200 bg-white transition-[width] duration-200 ease-in-out dark:border-zinc-800 dark:bg-zinc-900 ${
-          isOpen ? 'w-64' : 'w-0'
+          isOpen ? (menuOpenId ? 'w-80' : 'w-64') : 'w-0'
         } overflow-hidden`}
       >
-        <div className="flex w-64 items-center justify-between border-b border-zinc-200 px-4 py-4 dark:border-zinc-800">
+        <div className="flex min-w-64 items-center justify-between border-b border-zinc-200 px-4 py-4 dark:border-zinc-800">
           <span className="text-sm font-semibold text-zinc-900 dark:text-zinc-50">チャット履歴</span>
           <button
             onClick={handleNewChat}
@@ -82,7 +175,7 @@ export function SessionSidebar({
           </button>
         </div>
 
-        <div className="w-64 flex-1 overflow-y-auto py-2">
+        <div className="min-w-64 flex-1 overflow-y-auto py-2">
           {sidebarState.status === 'loading' && (
             <p className="px-4 py-4 text-xs text-zinc-400 dark:text-zinc-500">読み込み中...</p>
           )}
@@ -105,21 +198,95 @@ export function SessionSidebar({
           {sidebarState.status === 'ready' &&
             sidebarState.sessions.map((session) => {
               const isActive = session.id === currentSessionId;
+              const isEditing = editingId === session.id;
+              const isMenuOpen = menuOpenId === session.id;
+
               return (
-                <button
+                <div
                   key={session.id}
-                  onClick={() => handleSelectSession(session.id)}
-                  className={`w-full px-4 py-3 text-left transition-colors hover:bg-zinc-100 dark:hover:bg-zinc-800 ${
+                  className={`group relative flex items-center transition-colors hover:bg-zinc-100 dark:hover:bg-zinc-800 ${
                     isActive ? 'bg-zinc-100 dark:bg-zinc-800' : ''
                   }`}
                 >
-                  <p className="truncate text-sm font-medium text-zinc-900 dark:text-zinc-50">
-                    {session.title ?? '無題のチャット'}
-                  </p>
-                  <p className="mt-0.5 text-xs text-zinc-400 dark:text-zinc-500">
-                    {new Date(session.createdAt).toLocaleDateString('ja-JP')}
-                  </p>
-                </button>
+                  <button
+                    onClick={() => handleSelectSession(session.id)}
+                    className="min-w-0 flex-1 px-4 py-3 text-left"
+                    disabled={isEditing}
+                  >
+                    {isEditing ? (
+                      <input
+                        type="text"
+                        value={editTitle}
+                        onChange={(e) => setEditTitle(e.target.value)}
+                        onKeyDown={(e) => handleEditKeyDown(e, session.id)}
+                        onBlur={() => handleSaveEdit(session.id)}
+                        autoFocus
+                        className="w-full rounded border border-zinc-300 bg-white px-2 py-1 text-sm text-zinc-900 outline-none focus:border-zinc-500 dark:border-zinc-600 dark:bg-zinc-800 dark:text-zinc-50 dark:focus:border-zinc-400"
+                        onClick={(e) => e.stopPropagation()}
+                      />
+                    ) : (
+                      <>
+                        <p className="truncate text-sm font-medium text-zinc-900 dark:text-zinc-50">
+                          {session.title ?? '無題のチャット'}
+                        </p>
+                        <p className="mt-0.5 text-xs text-zinc-400 dark:text-zinc-500">
+                          {new Date(session.createdAt).toLocaleDateString('ja-JP')}
+                        </p>
+                      </>
+                    )}
+                  </button>
+
+                  {/* 縦三点ドットアイコン */}
+                  {!isEditing && (
+                    <div className="relative" ref={isMenuOpen ? menuRef : undefined}>
+                      <button
+                        onClick={(e) => handleMenuToggle(e, session.id)}
+                        className={`mr-2 flex h-7 w-7 shrink-0 items-center justify-center rounded text-zinc-400 transition-colors hover:bg-zinc-200 hover:text-zinc-700 dark:text-zinc-500 dark:hover:bg-zinc-700 dark:hover:text-zinc-200 ${
+                          isMenuOpen ? 'bg-zinc-200 text-zinc-700 dark:bg-zinc-700 dark:text-zinc-200' : 'opacity-0 group-hover:opacity-100'
+                        }`}
+                        aria-label="メニュー"
+                      >
+                        <svg
+                          xmlns="http://www.w3.org/2000/svg"
+                          width="14"
+                          height="14"
+                          viewBox="0 0 24 24"
+                          fill="currentColor"
+                        >
+                          <circle cx="12" cy="5" r="2" />
+                          <circle cx="12" cy="12" r="2" />
+                          <circle cx="12" cy="19" r="2" />
+                        </svg>
+                      </button>
+
+                      {/* アクションメニュー */}
+                      {isMenuOpen && (
+                        <div className="absolute right-0 top-8 z-10 w-28 rounded-md border border-zinc-200 bg-white py-1 shadow-lg dark:border-zinc-700 dark:bg-zinc-800">
+                          <button
+                            onClick={() => handleStartEdit(session)}
+                            className="flex w-full items-center gap-2 px-3 py-2 text-left text-sm text-zinc-700 hover:bg-zinc-100 dark:text-zinc-200 dark:hover:bg-zinc-700"
+                          >
+                            <svg xmlns="http://www.w3.org/2000/svg" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+                              <path d="M11 4H4a2 2 0 0 0-2 2v14a2 2 0 0 0 2 2h14a2 2 0 0 0 2-2v-7" />
+                              <path d="M18.5 2.5a2.121 2.121 0 0 1 3 3L12 15l-4 1 1-4 9.5-9.5z" />
+                            </svg>
+                            編集
+                          </button>
+                          <button
+                            onClick={() => handleStartDelete(session.id)}
+                            className="flex w-full items-center gap-2 px-3 py-2 text-left text-sm text-red-600 hover:bg-red-50 dark:text-red-400 dark:hover:bg-red-900/20"
+                          >
+                            <svg xmlns="http://www.w3.org/2000/svg" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+                              <polyline points="3 6 5 6 21 6" />
+                              <path d="M19 6v14a2 2 0 0 1-2 2H7a2 2 0 0 1-2-2V6m3 0V4a2 2 0 0 1 2-2h4a2 2 0 0 1 2 2v2" />
+                            </svg>
+                            削除
+                          </button>
+                        </div>
+                      )}
+                    </div>
+                  )}
+                </div>
               );
             })}
         </div>
@@ -146,6 +313,36 @@ export function SessionSidebar({
           <polyline points="15 18 9 12 15 6" />
         </svg>
       </button>
+
+      {/* 削除確認ダイアログ */}
+      {deleteConfirmId && (
+        <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/50">
+          <div className="mx-4 w-full max-w-sm rounded-lg bg-white p-6 shadow-xl dark:bg-zinc-800">
+            <h3 className="text-base font-semibold text-zinc-900 dark:text-zinc-50">
+              チャットを削除しますか？
+            </h3>
+            <p className="mt-2 text-sm text-zinc-500 dark:text-zinc-400">
+              このチャットセッションと全てのメッセージが削除されます。この操作は取り消せません。
+            </p>
+            <div className="mt-4 flex justify-end gap-3">
+              <button
+                onClick={handleCancelDelete}
+                disabled={deleting}
+                className="rounded-md px-4 py-2 text-sm font-medium text-zinc-700 transition-colors hover:bg-zinc-100 dark:text-zinc-300 dark:hover:bg-zinc-700"
+              >
+                キャンセル
+              </button>
+              <button
+                onClick={handleConfirmDelete}
+                disabled={deleting}
+                className="rounded-md bg-red-600 px-4 py-2 text-sm font-medium text-white transition-colors hover:bg-red-700 disabled:opacity-50"
+              >
+                {deleting ? '削除中...' : '削除'}
+              </button>
+            </div>
+          </div>
+        </div>
+      )}
     </div>
   );
 }

--- a/apps/frontend/src/lib/api/chat.ts
+++ b/apps/frontend/src/lib/api/chat.ts
@@ -55,6 +55,33 @@ export async function getChatMessages(
   return data.messages;
 }
 
+export async function updateChatSession(
+  sessionId: string,
+  title: string,
+  token: string,
+): Promise<ChatSession> {
+  return request<ChatSession>(`/chat/sessions/${sessionId}`, token, {
+    method: 'PATCH',
+    body: JSON.stringify({ title }),
+  });
+}
+
+export async function deleteChatSession(
+  sessionId: string,
+  token: string,
+): Promise<void> {
+  const res = await fetch(`${backendUrl}/chat/sessions/${sessionId}`, {
+    method: 'DELETE',
+    headers: {
+      Authorization: `Bearer ${token}`,
+    },
+  });
+  if (!res.ok) {
+    const text = await res.text();
+    throw new Error(`APIエラー (${res.status}): ${text}`);
+  }
+}
+
 export async function sendChatMessage(
   sessionId: string,
   message: string,


### PR DESCRIPTION
## Summary
- チャットセッションのタイトル編集（`PATCH /api/v1/chat/sessions/:id`）と削除（`DELETE /api/v1/chat/sessions/:id`）エンドポイントを追加
- サイドバーの各チャットセッションに縦三点ドットアイコン（⋮）を配置し、編集・削除のアクションメニューを実装
- タイトルのインライン編集（Enter確定、Escape キャンセル、空文字不可バリデーション）を実装
- 削除時の確認ダイアログを実装し、現在表示中のセッション削除時は新規チャット画面に遷移

## Test plan
- [ ] サイドバーの各チャットにホバーで縦三点ドットが表示されることを確認
- [ ] ドットクリックで編集・削除メニューが表示されることを確認
- [ ] 編集でタイトルが変更できることを確認（Enter / フォーカスアウト）
- [ ] Escapeで編集がキャンセルされることを確認
- [ ] 空タイトルでは保存されないことを確認
- [ ] 削除で確認ダイアログが表示され、確認後にセッションが削除されることを確認
- [ ] 現在閲覧中のセッション削除後、新規チャット画面に遷移することを確認

Closes #219

🤖 Generated with [Claude Code](https://claude.com/claude-code)