### PR TITLE
remove: 削除済みRoute53ホストゾーンのCDKキャッシュを除去 #233

### DIFF
--- a/infra/cdk.context.json
+++ b/infra/cdk.context.json
@@ -13,13 +13,5 @@
     "ap-northeast-1a",
     "ap-northeast-1c",
     "ap-northeast-1d"
-  ],
-  "hosted-zone:account=502140064658:domainName=jun-eg.site:region=ap-northeast-1": {
-    "Id": "/hostedzone/Z092401816IOTG2WKLJSF",
-    "Name": "jun-eg.site."
-  },
-  "hosted-zone:account=502140064658:domainName=jun-eg.site:region=us-east-1": {
-    "Id": "/hostedzone/Z092401816IOTG2WKLJSF",
-    "Name": "jun-eg.site."
-  }
+  ]
 }


### PR DESCRIPTION
## 概要

Issue #233 (AWS → Cloud Run 完全移行) の **section 5「AWS リソース削除」** の対応。

2026-04-24 に AWS 上のリソースを完全削除したため、`infra/cdk.context.json` に残っていた stale な Route53 ホストゾーン lookup キャッシュを除去する。

## AWS 側で削除済みのリソース（dev: 502140064658 / prod: 882856016971）

| カテゴリ | 削除対象 |
|---|---|
| CloudFormation スタック | Bootstrap, Network, Data, App, Edge, Certificate(us-east-1), CDKToolkit(×2 regions) |
| S3 | `credit-checker-{dev,prod}`, CDK assets バケット×4 |
| RDS | PostgreSQL instance×2 + 手動スナップショット×2 |
| Secrets Manager | 計8件（dev/prod × 4種） |
| ECR | `credit-checker-{backend,frontend,backend-migrator}` ×2 + CDK container assets ×2 |
| Route53 HostedZone | `jun-eg.site` (prod: Z06351332LPU33Z3D1MTL) / `jun-eg.site` (dev: Z092401816IOTG2WKLJSF) |
| CloudWatch Logs | 全ロググループ |

## このPRでの変更

- `infra/cdk.context.json` から削除済みの dev Route53 ホストゾーン (`Z092401816IOTG2WKLJSF`) の lookup キャッシュを除去

## 備考（後続タスク）

- **Namecheap の DNS 設定**: 現在 prod Route53 の NS を向いていたため `jun-eg.site` は一時的に名前解決不能。Cloud Run 移行完了後に Cloud DNS / 他 DNS に切替が必要（Issue #233 section 4）
- **GitHub Actions**: Bootstrap スタック削除により AWS OIDC ロールが消滅。`deploy.yml` / `reusable-app-deploy.yml` / `reusable-infra-deploy.yml` / `dev-startup.yml` / `dev-shutdown.yml` は現在動作しない。Cloud Run 向けに書き換える必要あり（Issue #233 section 3）
- **`infra/` ディレクトリのコード本体**: Issue #233 section 6 で対応予定

## Test plan

- [x] AWS Console で両アカウントに残存リソースが無いこと確認済み
- [x] `cdk.context.json` の JSON 妥当性確認

Closes: Issue #233 の section 5 部分

🤖 Generated with [Claude Code](https://claude.com/claude-code)